### PR TITLE
fix: FTS and vector search returning empty results

### DIFF
--- a/src/engine/evaluator.rs
+++ b/src/engine/evaluator.rs
@@ -75,12 +75,8 @@ impl Evaluator {
                     // to build SQL IN conditions (same pattern as FTS).
                     let search_opts = query_opts_to_search_opts(&opts, target);
                     let search_result = store.execute_similar(&query_text, &search_opts, target)?;
-                    let key_field = match target {
-                        QueryTarget::Knowledge => "name",
-                        QueryTarget::Statement => "triple",
-                    };
                     let keys: Vec<String> = search_result.rows.iter()
-                        .filter_map(|row| row.get(key_field).and_then(|v| v.as_str()).map(String::from))
+                        .filter_map(|row| row.get(target.key_column()).and_then(|v| v.as_str()).map(String::from))
                         .collect();
                     if keys.is_empty() {
                         builder.add_condition("1=0".to_string(), Vec::new());
@@ -166,10 +162,7 @@ fn query_opts_to_search_opts(opts: &QueryOpts, target: QueryTarget) -> SearchOpt
 /// For Knowledge: `name IN (?, ?, ...)`
 /// For Statement: `triple IN (?, ?, ...)`
 fn build_key_match_condition(target: QueryTarget, keys: &[String]) -> (String, Vec<serde_json::Value>) {
-    let pk_column = match target {
-        QueryTarget::Knowledge => "name",
-        QueryTarget::Statement => "triple",
-    };
+    let pk_column = target.key_column();
     let params: Vec<serde_json::Value> = keys.iter()
         .map(|k| serde_json::Value::String(k.clone()))
         .collect();
@@ -340,6 +333,43 @@ mod tests {
             &mock,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn eval_similar_inside_knowledge() {
+        // $similar returns rows with "name" field (not "key")
+        let mut similar_row = serde_json::Map::new();
+        similar_row.insert("name".to_string(), json!("rust"));
+        similar_row.insert("distance".to_string(), json!(0.1));
+
+        let mut query_row = serde_json::Map::new();
+        query_row.insert("name".to_string(), json!("rust"));
+
+        let mock = MockStorage::with_search_results(vec![query_row], vec![similar_row]);
+        let result = Evaluator::execute(
+            &json!(["$knowledge", ["$similar", "systems programming"]]),
+            &mock,
+        ).unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0]["name"], json!("rust"));
+    }
+
+    #[test]
+    fn eval_similar_inside_statement() {
+        // $similar returns rows with "triple" field for statements
+        let mut similar_row = serde_json::Map::new();
+        similar_row.insert("triple".to_string(), json!("Alice,knows,Bob"));
+        similar_row.insert("distance".to_string(), json!(0.2));
+
+        let mut query_row = serde_json::Map::new();
+        query_row.insert("triple".to_string(), json!("Alice,knows,Bob"));
+
+        let mock = MockStorage::with_search_results(vec![query_row], vec![similar_row]);
+        let result = Evaluator::execute(
+            &json!(["$statement", ["$similar", "relationships"]]),
+            &mock,
+        ).unwrap();
+        assert_eq!(result.rows.len(), 1);
     }
 
     #[test]

--- a/src/engine/evaluator.rs
+++ b/src/engine/evaluator.rs
@@ -75,8 +75,12 @@ impl Evaluator {
                     // to build SQL IN conditions (same pattern as FTS).
                     let search_opts = query_opts_to_search_opts(&opts, target);
                     let search_result = store.execute_similar(&query_text, &search_opts, target)?;
+                    let key_field = match target {
+                        QueryTarget::Knowledge => "name",
+                        QueryTarget::Statement => "triple",
+                    };
                     let keys: Vec<String> = search_result.rows.iter()
-                        .filter_map(|row| row.get("key").and_then(|v| v.as_str()).map(String::from))
+                        .filter_map(|row| row.get(key_field).and_then(|v| v.as_str()).map(String::from))
                         .collect();
                     if keys.is_empty() {
                         builder.add_condition("1=0".to_string(), Vec::new());

--- a/src/model/query.rs
+++ b/src/model/query.rs
@@ -72,4 +72,12 @@ impl QueryTarget {
             QueryTarget::Statement => "statement",
         }
     }
+
+    /// Primary key column name for this target, used for FTS/vector key matching.
+    pub fn key_column(&self) -> &'static str {
+        match self {
+            QueryTarget::Knowledge => "name",
+            QueryTarget::Statement => "triple",
+        }
+    }
 }

--- a/src/storage/sqlite_store.rs
+++ b/src/storage/sqlite_store.rs
@@ -135,6 +135,11 @@ impl SqliteStore {
             ))
             .map_err(StorageError::from)?;
 
+        // Rebuild FTS index from existing docs_meta rows
+        self.conn
+            .execute_batch("INSERT INTO docs_fts(docs_fts) VALUES('rebuild')")
+            .map_err(StorageError::from)?;
+
         Ok(())
     }
 

--- a/src/storage/sqlite_store.rs
+++ b/src/storage/sqlite_store.rs
@@ -343,6 +343,28 @@ mod tests {
     }
 
     #[test]
+    fn fts_survives_reopen() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+
+        // Insert data in first connection
+        {
+            let store = SqliteStore::open(&db_path).unwrap();
+            store
+                .upsert_doc("knowledge", "rust", &test_doc("rust", "Rust is a systems programming language", ""))
+                .unwrap();
+        }
+
+        // Reopen (triggers DROP + CREATE + rebuild) and verify search still works
+        {
+            let store = SqliteStore::open(&db_path).unwrap();
+            let results = store.search("programming", &SearchOpts::default()).unwrap();
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].key, "rust");
+        }
+    }
+
+    #[test]
     fn delete_doc() {
         let (_dir, store) = setup();
         store


### PR DESCRIPTION
## Summary

- **FTS index lost on every startup**: `init_schema()` drops and recreates the FTS5 virtual table but never rebuilds the index from existing `docs_meta` rows. Every `hypatia` CLI invocation starts fresh, so existing data becomes unsearchable. Added `INSERT INTO docs_fts(docs_fts) VALUES('rebuild')` after table recreation.
- **`$similar` key field mismatch**: the evaluator extracted vector search results using `row.get("key")`, but `execute_similar` returns `"name"` (for knowledge) or `"triple"` (for statement). Keys were always empty, producing a `1=0` condition. Now selects the correct field based on query target.

## Test plan

- [x] `hypatia search "甲木"` returns matching knowledge + statement entries
- [x] `hypatia query '["$knowledge", ["$search", "八字"]]'` returns results via JSE
- [x] `hypatia query '["$knowledge", ["$similar", "天干五行属性"]]'` returns semantically ranked results
- [x] 17 related unit tests pass (`cargo test -- search similar evaluator fts vector`)