### PR TITLE
fix: resolve -s short flag conflict in CLI

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -46,7 +46,7 @@ enum Commands {
         #[arg(short, long, default_value = "")]
         tags: String,
         /// Synonyms (comma-separated)
-        #[arg(short, long, default_value = "")]
+        #[arg(short = 'y', long, default_value = "")]
         synonyms: String,
         /// Binary figure references (comma-separated, e.g. binary://euclid/fig1.png)
         #[arg(short, long, default_value = "")]
@@ -84,7 +84,7 @@ enum Commands {
         #[arg(short, long, default_value = "")]
         data: String,
         /// Synonyms as JSON: {"subject":["Bob"],"predicate":["leads"],"object":["DB"]}
-        #[arg(short, long)]
+        #[arg(short = 'y', long)]
         synonyms: Option<String>,
         #[arg(short, long, default_value = "default")]
         shelf: String,


### PR DESCRIPTION
## Summary
- `knowledge-create` 和 `statement-create` 的 `synonyms` 和 `shelf` 参数都映射到 `-s`，导致 panic
- 将 `synonyms` 改为 `-y`

## Test
- `hypatia knowledge-create --help` 不再 panic