### PR TITLE
feat(skills): add hypatia-dream consolidation

### DIFF
--- a/dsh-hypatia/skills/hypatia-dream/SKILL.md
+++ b/dsh-hypatia/skills/hypatia-dream/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: hypatia-dream
+description: "Run a deliberate, incremental Hypatia graph-consolidation pass at the end of a work period, like sleep-time knowledge organization. Trigger only for an explicit batch closeout or sleep-time request, not ordinary knowledge CRUD or a one-off triple. With no explicit --mode, treat these Chinese closeout signals as apply: '下班了', '收工了', '今天先到这', '本阶段结束', '阶段性收尾', '做个好梦', and '睡前整理一下'. Treat these as report-only: '先整理看看', '做个梦看看', '睡前审阅一下', '看看知识之间的关系', '只出报告', and '先别修改'. Analyze Statement triples as primary evidence, read Knowledge bodies only for disambiguation, then report or safely apply high-confidence relationship additions and corrections."
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob
+argument-hint: "[shelf] [--mode report|apply]"
+---
+
+# Hypatia Dream
+
+Perform an incremental, relationship-focused consolidation pass over one Hypatia shelf. The purpose is to make the graph more coherent after new knowledge arrives, not to summarize, rewrite, delete, or otherwise curate the knowledge nodes themselves.
+
+Treat the graph as a personal knowledge base: inspect its whole available relationship topology rather than imposing a small relationship window. Keep the analysis disciplined by treating Statement triples as the primary evidence. Knowledge bodies may clarify entity identity or resolve an apparent contradiction, but they are not a license to invent weak associations.
+
+## Trigger And Mode Resolution
+
+Trigger this skill only for a deliberate batch consolidation at a work-period boundary or an explicitly requested dream-time review. Do not trigger it for ordinary knowledge CRUD, a direct one-off triple request, an entity lookup, a relationship query, or automatic conversation-memory extraction; those belong to `hypatia` or `hypatia-memory`.
+
+Interpret the optional shelf name from the request; use `default` when it is omitted.
+
+Resolve the mode in this order:
+
+1. An explicit `--mode report` or `--mode apply` always wins.
+2. Without an explicit mode, treat these closeout signals and clear equivalents as `apply`: `下班了`, `收工了`, `今天先到这`, `本阶段结束`, `阶段性收尾`, `做个好梦`, and `睡前整理一下`.
+3. Without an explicit mode, treat these preview signals and clear equivalents as `report`: `先整理看看`, `做个梦看看`, `睡前审阅一下`, `看看知识之间的关系`, `只出报告`, and `先别修改`.
+4. If both signal classes appear in one request, ask the user to choose a mode. Do not assume `apply`.
+5. A direct but otherwise unspecified invocation defaults to `report`.
+
+The modes have these effects:
+
+- `report` reads the shelf and returns a structured report. It creates no state marker and changes no knowledge or statement.
+- `apply` may add a missing statement or replace an explicitly contradicted statement. It never creates, edits, or deletes a regular Knowledge entry.
+
+Before every Hypatia CLI command, briefly state the goal, the exact command, why that query or mutation is appropriate, and the expected result. Use one-shot commands only; do not use `hypatia repl`.
+
+## Hypatia Conventions To Preserve
+
+Use the actual Statement fields and CLI terminology: `head`, `relation`, and `tail`. Do not describe them as fields named `subject`, `predicate`, or `object` in commands or reports.
+
+Prefer the relationship vocabulary already established by Hypatia's semantic-memory design:
+
+- `is_a` for a clear category relationship.
+- `refines` for a more precise form of an existing concept.
+- `extends` for an addition that builds on an existing concept.
+- `supersedes` for an explicit replacement of an older concept or decision.
+- `derivedFrom` for a clear provenance relationship.
+
+Preserve existing predicate spellings. `belongTo` and `summary` are operational relationships maintained by the memory system; do not reinterpret, delete, replace, or add semantic links to their message/session/summary endpoints. Likewise, do not reorganize archive metadata relationships such as `is_a archive`.
+
+Do not use a vague catch-all relationship such as `related_to` merely because two entries share words or a topic. Omit uncertain candidates.
+
+## Resolve The CLI And Snapshot Boundary
+
+1. Resolve the binary in this order: `hypatia` on `PATH`, `./target/debug/hypatia`, then `./target/release/hypatia`. Stop and report a concrete blocker if none exists.
+2. Set `SHELF` to the requested shelf or `default`.
+3. Record a UTC run-start timestamp before reading graph data. Format it as `YYYY-MM-DD HH:MM:SS`, which compares correctly with Hypatia's `created_at` values.
+4. Query the latest successful apply marker in the same shelf:
+
+```bash
+hypatia query '{"$knowledge":[["$contains","tags","hypatia-dream-run"]],"limit":1}' -s "<SHELF>"
+```
+
+A marker is a system-tagged Knowledge entry created by this skill after a successful `apply`. Its content contains a `processed_through` timestamp. Read that value, not the marker entry's `created_at`: a run can create statements after its snapshot begins, and using the marker creation time could skip concurrent new information.
+
+5. Define the collection interval as follows:
+
+- If a valid marker exists, use `processed_through < created_at <= run_started_at`.
+- If there is no valid marker, this is the first consolidation pass. Collect all pre-snapshot triples and knowledge entries.
+- A malformed marker is not a reason to guess. Report it and treat the run as a first pass unless the user supplies an explicit baseline.
+
+`report` mode must not advance this watermark. This lets a later `apply` reconsider the same proposed changes. Only a completed `apply` writes a marker.
+
+## Gather The Working Set
+
+Retrieve the complete pre-snapshot relationship graph. Use a large, explicit limit because the shelf is personal and the user requested no relationship-range cap:
+
+```bash
+hypatia query '{"$statement":[["$lte","created_at","<RUN_STARTED_AT>"]],"limit":10000}' -s "<SHELF>"
+```
+
+Retrieve the newly created triples with the collection interval. For a first pass, omit the lower-bound condition:
+
+```bash
+hypatia query '{"$statement":[["$and",["$gt","created_at","<BASELINE>"],["$lte","created_at","<RUN_STARTED_AT>"]]],"limit":10000}' -s "<SHELF>"
+```
+
+Also retrieve new Knowledge entries from the same interval. Exclude internal log, session, summary, and dream-marker entries by tag. For a first pass, omit the lower-bound condition:
+
+```bash
+hypatia query '{"$knowledge":[["$and",["$gt","created_at","<BASELINE>"],["$lte","created_at","<RUN_STARTED_AT>"],["$not",["$or",["$contains","tags","message"],["$contains","tags","session"],["$contains","tags","summary"],["$contains","tags","hypatia-dream-run"]]]]],"limit":10000}' -s "<SHELF>"
+```
+
+The new Knowledge set can include an unlinked node. It is eligible for one well-supported relationship to an older graph node, but only after its body and the prospective target's body have been read for disambiguation. Do not manufacture a relation solely to make an isolated node connected.
+
+For each potentially affected node, fetch its Knowledge entry by exact name and inspect its one-hop incident triples from the full graph. Read only the bodies needed to explain an entity match, source lineage, category, refinement, extension, supersession, or direct contradiction. Never use conversation text, session summaries, or system markers as semantic evidence.
+
+## Reason About Relationships
+
+Work from the newly added triples and eligible new Knowledge nodes toward the full existing graph. For every candidate, identify:
+
+- The exact new evidence: triple or Knowledge entry name and the relevant wording.
+- The supporting old graph context: exact triples and, when needed, the old node body.
+- The proposed triple in `(head, relation, tail)` form.
+- A confidence level and a short explanation of why that relation is more precise than its alternatives.
+
+Classify each outcome as exactly one of these:
+
+1. **Add**: a missing, non-duplicate triple is directly supported by the new evidence and the existing graph vocabulary.
+2. **Replace**: a specific old triple is directly contradicted by newer, unambiguous evidence. Name both triples. Prefer adding `supersedes` when the old idea remains historically useful; delete and replace only when the old relation itself is false.
+3. **No change**: evidence is duplicate, weak, ambiguous, historical rather than contradictory, or depends on a protected/system relation.
+
+A candidate must be high confidence before it may be applied. Similarity, shared tags, or lexical overlap alone are never high confidence.
+
+Before a replacement, inspect the old statement's `content`, `tr_start`, and `tr_end`. Do not apply a replacement when `tr_start` or `tr_end` is populated: the CLI cannot recreate temporal bounds. Also do not apply a replacement if the original statement metadata cannot be faithfully preserved through `statement-create`; report it instead.
+
+## Apply Changes
+
+In `report` mode, stop after producing the report. Do not write a marker.
+
+In `apply` mode, execute this sequence only after the analysis identifies high-confidence changes:
+
+1. Re-query every proposed old and new triple immediately before mutating. Skip stale plans, existing additions, and replacements whose source triple no longer matches the reviewed evidence.
+2. Before the first destructive deletion, export the shelf to a timestamped backup directory and report the destination. Use `hypatia export`; create the destination directory explicitly when needed.
+3. For a replacement, delete only the exact reviewed source triple, then create the exact reviewed replacement. Preserve `data`, positional `synonyms`, and `scopes` from the source statement when they apply. Never delete first if that metadata or a temporal bound cannot be preserved.
+4. For an addition, create only the exact reviewed triple. Do not create supporting nodes or generic fallback links.
+5. Re-query each created triple and every intended removal. If verification fails, stop, report the partial outcome and backup location, and do not create a watermark.
+
+After all intended changes verify, write one run marker in the same shelf:
+
+```bash
+hypatia knowledge-create "hypatia-dream-run-<UTC_COMPACT_TIMESTAMP>" \
+  -d "schema: 1
+mode: apply
+processed_through: <RUN_STARTED_AT>
+added: <COUNT>
+replaced: <COUNT>
+report: Hypatia Dream completed successfully" \
+  -t "system,hypatia-dream-run" \
+  -s "<SHELF>"
+```
+
+The marker is operational metadata, not semantic knowledge. Never attach a Statement triple to it or use it as relationship evidence.
+
+If no high-confidence graph changes exist, `apply` may still write the marker after reporting a verified no-op. This records that the interval has been reviewed without falsely claiming a graph mutation.
+
+## Required Report
+
+Return the report in this structure, in the user's language:
+
+```markdown
+# Hypatia Dream Report
+
+## Scope
+- Shelf: `<name>`
+- Mode: `report` or `apply`
+- Baseline: first pass, or `<processed_through>`
+- Snapshot boundary: `<run_started_at>`
+- Reviewed: `<new knowledge count>` Knowledge entries and `<new statement count>` new triples against `<total statement count>` existing triples
+
+## Relationship Findings
+### Add
+- `(head, relation, tail)` [high confidence]
+  Evidence: ...
+  Existing context: ...
+
+### Replace
+- `(old head, old relation, old tail)` -> `(new head, new relation, new tail)` [high confidence]
+  Evidence: ...
+  Rationale: ...
+
+### No Change
+- Item: ...
+  Reason: duplicate, insufficient evidence, protected system relation, or metadata/temporal safety restriction.
+
+## Outcome
+- Planned or applied additions: `<count>`
+- Planned or applied replacements: `<count>`
+- Skipped candidates: `<count>`
+- Backup: `<path>` or `not needed`
+- Watermark: `<processed_through>` written only after a verified `apply`, otherwise `unchanged`
+```
+
+Be concise but include every command that changed state and every exact triple it affected. Do not claim a relationship was corrected unless its post-mutation query verified the result.

--- a/dsh-hypatia/skills/hypatia-dream/SKILL.md
+++ b/dsh-hypatia/skills/hypatia-dream/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hypatia-dream
-description: "Run a deliberate, incremental Hypatia graph-consolidation pass at the end of a work period, like sleep-time knowledge organization. Trigger only for an explicit batch closeout or sleep-time request, not ordinary knowledge CRUD or a one-off triple. With no explicit --mode, treat these Chinese closeout signals as apply: '下班了', '收工了', '今天先到这', '本阶段结束', '阶段性收尾', '做个好梦', and '睡前整理一下'. Treat these as report-only: '先整理看看', '做个梦看看', '睡前审阅一下', '看看知识之间的关系', '只出报告', and '先别修改'. Analyze Statement triples as primary evidence, read Knowledge bodies only for disambiguation, then report or safely apply high-confidence relationship additions and corrections."
+description: "Run an incremental Hypatia graph-consolidation pass at a work-period boundary, like sleep-time knowledge organization. Trigger only for an explicit batch closeout or dream-time review, not ordinary knowledge CRUD, a one-off triple, or a lookup. Without an explicit --mode, these mean apply: '下班了', '收工了', '今天先到这', '本阶段结束', '阶段性收尾', '做个好梦', '睡前整理一下', 'done for the day', 'wrapping up', 'call it a night'. These mean report-only: '先整理看看', '做个梦看看', '睡前审阅一下', '看看知识之间的关系', '只出报告', '先别修改', 'just show me first', 'do not change anything yet'. Statement triples are the primary evidence; Knowledge bodies only disambiguate."
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob
 argument-hint: "[shelf] [--mode report|apply]"
@@ -21,8 +21,8 @@ Interpret the optional shelf name from the request; use `default` when it is omi
 Resolve the mode in this order:
 
 1. An explicit `--mode report` or `--mode apply` always wins.
-2. Without an explicit mode, treat these closeout signals and clear equivalents as `apply`: `下班了`, `收工了`, `今天先到这`, `本阶段结束`, `阶段性收尾`, `做个好梦`, and `睡前整理一下`.
-3. Without an explicit mode, treat these preview signals and clear equivalents as `report`: `先整理看看`, `做个梦看看`, `睡前审阅一下`, `看看知识之间的关系`, `只出报告`, and `先别修改`.
+2. Without an explicit mode, treat these closeout signals and clear equivalents as `apply`: `下班了`, `收工了`, `今天先到这`, `本阶段结束`, `阶段性收尾`, `做个好梦`, `睡前整理一下`, `done for the day`, `wrapping up`, and `call it a night`.
+3. Without an explicit mode, treat these preview signals and clear equivalents as `report`: `先整理看看`, `做个梦看看`, `睡前审阅一下`, `看看知识之间的关系`, `只出报告`, `先别修改`, `just show me first`, and `do not change anything yet`.
 4. If both signal classes appear in one request, ask the user to choose a mode. Do not assume `apply`.
 5. A direct but otherwise unspecified invocation defaults to `report`.
 
@@ -52,15 +52,29 @@ Do not use a vague catch-all relationship such as `related_to` merely because tw
 ## Resolve The CLI And Snapshot Boundary
 
 1. Resolve the binary in this order: `hypatia` on `PATH`, `./target/debug/hypatia`, then `./target/release/hypatia`. Stop and report a concrete blocker if none exists.
-2. Set `SHELF` to the requested shelf or `default`.
-3. Record a UTC run-start timestamp before reading graph data. Format it as `YYYY-MM-DD HH:MM:SS`, which compares correctly with Hypatia's `created_at` values.
+2. Set `SHELF` to the requested shelf or `default`, then confirm that shelf is connected before doing anything else:
+
+```bash
+hypatia list
+```
+
+Every Hypatia command fails when the target shelf is not connected, and the whole CLI fails at startup when any registered shelf uses the legacy DuckDB layout. Both are blockers to report, not conditions to work around.
+
+3. Record a UTC run-start timestamp before reading graph data:
+
+```bash
+date -u '+%Y-%m-%d %H:%M:%S'
+```
+
+SQLite's `'now'` is UTC, so this is the same clock Hypatia stamps with. Hypatia writes `created_at` as `%Y-%m-%d %H:%M:%f`, so stored values carry milliseconds (`2026-09-02 08:50:08.790`) and compare as TEXT. A second-resolution boundary is therefore slightly conservative, deliberately so: `created_at <= "2026-09-02 08:50:08"` excludes `2026-09-02 08:50:08.790`, and because the watermark is written at the same resolution, the next run's `created_at > "2026-09-02 08:50:08"` picks that row back up. Do not pad the boundary with `.999` and do not truncate stored values to close the apparent gap — either one reintroduces a real gap.
+
 4. Query the latest successful apply marker in the same shelf:
 
 ```bash
 hypatia query '{"$knowledge":[["$contains","tags","hypatia-dream-run"]],"limit":1}' -s "<SHELF>"
 ```
 
-A marker is a system-tagged Knowledge entry created by this skill after a successful `apply`. Its content contains a `processed_through` timestamp. Read that value, not the marker entry's `created_at`: a run can create statements after its snapshot begins, and using the marker creation time could skip concurrent new information.
+Query results are ordered by `created_at DESC`, so `limit:1` returns the most recent marker. A marker is a system-tagged Knowledge entry created by this skill after a successful `apply`. Its content contains a `processed_through` timestamp. Read that value, not the marker entry's `created_at`: a run can create statements after its snapshot begins, and using the marker creation time could skip concurrent new information.
 
 5. Define the collection interval as follows:
 
@@ -90,6 +104,8 @@ Also retrieve new Knowledge entries from the same interval. Exclude internal log
 hypatia query '{"$knowledge":[["$and",["$gt","created_at","<BASELINE>"],["$lte","created_at","<RUN_STARTED_AT>"],["$not",["$or",["$contains","tags","message"],["$contains","tags","session"],["$contains","tags","summary"],["$contains","tags","hypatia-dream-run"]]]]],"limit":10000}' -s "<SHELF>"
 ```
 
+`limit` is a hard cap, not a promise. Compare the returned row count with the limit for each of the three queries above. If they are equal, the result was truncated by `ORDER BY created_at DESC` and the graph in hand is incomplete. Stop, report the truncation as a blocker, and apply nothing: a relation can only be judged contradicted, duplicate, or missing against the whole graph, and a truncated read would let this skill "correct" a relationship whose supporting evidence was simply cut off.
+
 The new Knowledge set can include an unlinked node. It is eligible for one well-supported relationship to an older graph node, but only after its body and the prospective target's body have been read for disambiguation. Do not manufacture a relation solely to make an isolated node connected.
 
 For each potentially affected node, fetch its Knowledge entry by exact name and inspect its one-hop incident triples from the full graph. Read only the bodies needed to explain an entity match, source lineage, category, refinement, extension, supersession, or direct contradiction. Never use conversation text, session summaries, or system markers as semantic evidence.
@@ -111,7 +127,16 @@ Classify each outcome as exactly one of these:
 
 A candidate must be high confidence before it may be applied. Similarity, shared tags, or lexical overlap alone are never high confidence.
 
-Before a replacement, inspect the old statement's `content`, `tr_start`, and `tr_end`. Do not apply a replacement when `tr_start` or `tr_end` is populated: the CLI cannot recreate temporal bounds. Also do not apply a replacement if the original statement metadata cannot be faithfully preserved through `statement-create`; report it instead.
+Before a replacement, inspect the old statement's `content`, `tr_start`, and `tr_end`. A query result omits NULL columns entirely, so an absent `tr_start` or `tr_end` key means the statement has no temporal bound — not that the information is unavailable.
+
+`statement-create` accepts only `--data`, `--synonyms`, and `--scopes`. It cannot set `tags`, cannot set `format`, cannot set `figures`, and cannot recreate a temporal bound. Report instead of replacing whenever the source statement has any of these:
+
+- a populated `tr_start` or `tr_end`;
+- a non-empty `content.tags`;
+- a `content.format` other than `markdown`;
+- a non-empty `content.figures`.
+
+Otherwise the statement is eligible, and the replacement must carry over `content.data`, positional `content.synonyms`, and `content.scopes` from the source.
 
 ## Apply Changes
 
@@ -119,11 +144,41 @@ In `report` mode, stop after producing the report. Do not write a marker.
 
 In `apply` mode, execute this sequence only after the analysis identifies high-confidence changes:
 
-1. Re-query every proposed old and new triple immediately before mutating. Skip stale plans, existing additions, and replacements whose source triple no longer matches the reviewed evidence.
-2. Before the first destructive deletion, export the shelf to a timestamped backup directory and report the destination. Use `hypatia export`; create the destination directory explicitly when needed.
-3. For a replacement, delete only the exact reviewed source triple, then create the exact reviewed replacement. Preserve `data`, positional `synonyms`, and `scopes` from the source statement when they apply. Never delete first if that metadata or a temporal bound cannot be preserved.
-4. For an addition, create only the exact reviewed triple. Do not create supporting nodes or generic fallback links.
-5. Re-query each created triple and every intended removal. If verification fails, stop, report the partial outcome and backup location, and do not create a watermark.
+1. Re-query every proposed old and new triple immediately before mutating. Use the exact-key form, which matches on the `triple` primary key:
+
+```bash
+hypatia query '{"$statement":[["$triple","<HEAD>","<RELATION>","<TAIL>"]],"limit":1}' -s "<SHELF>"
+```
+
+Skip a stale plan, an addition that already exists, and a replacement whose source triple no longer matches the reviewed evidence.
+
+2. If the run plans any replacement, export the shelf to a timestamped backup directory before the first replacement step and report the destination. `export` creates the destination directory itself, so do not pre-create it, and pass the shelf name as the first argument:
+
+```bash
+hypatia export "<SHELF>" "<BACKUP_DIR>"
+```
+
+3. For an addition, create only the exact reviewed triple. Do not create supporting nodes or generic fallback links.
+
+```bash
+hypatia statement-create "<HEAD>" "<RELATION>" "<TAIL>" -s "<SHELF>"
+```
+
+`statement.triple` is unique, so creating a triple that already exists fails with `UNIQUE constraint failed: statement.triple`. That means the relationship is already recorded: treat it as a no-op, count it as skipped, and continue. It is not a run failure.
+
+4. For a replacement, **create the new triple first, verify it, and only then delete the source triple.** A replacement changes at least one of `head`, `relation`, and `tail`, so the two triples have different primary keys and can coexist for the moment in between. This ordering has no window in which the old relationship is already gone and the new one does not yet exist. Never delete first.
+
+```bash
+hypatia statement-create "<NEW_HEAD>" "<NEW_RELATION>" "<NEW_TAIL>" \
+  -d "<SOURCE_DATA>" --synonyms '<SOURCE_SYNONYMS_JSON>' --scopes "<SOURCE_SCOPES>" -s "<SHELF>"
+hypatia statement-delete "<OLD_HEAD>" "<OLD_RELATION>" "<OLD_TAIL>" -s "<SHELF>"
+```
+
+Carry the source metadata across exactly, and omit any flag whose source value is empty — `--synonyms ""` is a hard parse error, not an empty value. `--synonyms` takes the positional form `{"head":[...],"relation":[...],"tail":[...]}`. `--scopes` is comma-separated and a trailing comma means global scope, so source scopes `["project-a",""]` are reproduced as `--scopes "project-a,"` and `[""]` as `--scopes ","`.
+
+If the create fails, nothing has been lost: report it and leave the source triple untouched. If the create succeeds but the delete fails, stop and report both triples as present — the graph is consistent but now carries a duplicate relationship, and a person must decide.
+
+5. Re-query each created triple and every intended removal with the same `$triple` form. A created triple must come back; a removed triple must return `No results found.` Note that `statement-delete` exits non-zero with `not found` when the triple is already gone; that is an already-applied removal rather than a failure, but confirm it by query before continuing. If any verification fails, stop, report the partial outcome and the backup location, and do not create a watermark.
 
 After all intended changes verify, write one run marker in the same shelf:
 
@@ -141,6 +196,8 @@ report: Hypatia Dream completed successfully" \
 
 The marker is operational metadata, not semantic knowledge. Never attach a Statement triple to it or use it as relationship evidence.
 
+A marker is still an ordinary Knowledge entry: it is full-text indexed and vector-embedded like any other, so it will surface in the user's own `hypatia search` and `hypatia similar` results. Keep the body to the fields above for that reason — never store report prose, analysis, or candidate lists in it. This skill never deletes an old marker; only the most recent one is ever read.
+
 If no high-confidence graph changes exist, `apply` may still write the marker after reporting a verified no-op. This records that the interval has been reviewed without falsely claiming a graph mutation.
 
 ## Required Report
@@ -156,6 +213,7 @@ Return the report in this structure, in the user's language:
 - Baseline: first pass, or `<processed_through>`
 - Snapshot boundary: `<run_started_at>`
 - Reviewed: `<new knowledge count>` Knowledge entries and `<new statement count>` new triples against `<total statement count>` existing triples
+- Graph read: `<returned row count>` of `<limit>` rows, complete or truncated
 
 ## Relationship Findings
 ### Add

--- a/skills/hypatia-dream/SKILL.md
+++ b/skills/hypatia-dream/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: hypatia-dream
+description: "Run a deliberate, incremental Hypatia graph-consolidation pass at the end of a work period, like sleep-time knowledge organization. Trigger only for an explicit batch closeout or sleep-time request, not ordinary knowledge CRUD or a one-off triple. With no explicit --mode, treat these Chinese closeout signals as apply: '下班了', '收工了', '今天先到这', '本阶段结束', '阶段性收尾', '做个好梦', and '睡前整理一下'. Treat these as report-only: '先整理看看', '做个梦看看', '睡前审阅一下', '看看知识之间的关系', '只出报告', and '先别修改'. Analyze Statement triples as primary evidence, read Knowledge bodies only for disambiguation, then report or safely apply high-confidence relationship additions and corrections."
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob
+argument-hint: "[shelf] [--mode report|apply]"
+---
+
+# Hypatia Dream
+
+Perform an incremental, relationship-focused consolidation pass over one Hypatia shelf. The purpose is to make the graph more coherent after new knowledge arrives, not to summarize, rewrite, delete, or otherwise curate the knowledge nodes themselves.
+
+Treat the graph as a personal knowledge base: inspect its whole available relationship topology rather than imposing a small relationship window. Keep the analysis disciplined by treating Statement triples as the primary evidence. Knowledge bodies may clarify entity identity or resolve an apparent contradiction, but they are not a license to invent weak associations.
+
+## Trigger And Mode Resolution
+
+Trigger this skill only for a deliberate batch consolidation at a work-period boundary or an explicitly requested dream-time review. Do not trigger it for ordinary knowledge CRUD, a direct one-off triple request, an entity lookup, a relationship query, or automatic conversation-memory extraction; those belong to `hypatia` or `hypatia-memory`.
+
+Interpret the optional shelf name from the request; use `default` when it is omitted.
+
+Resolve the mode in this order:
+
+1. An explicit `--mode report` or `--mode apply` always wins.
+2. Without an explicit mode, treat these closeout signals and clear equivalents as `apply`: `下班了`, `收工了`, `今天先到这`, `本阶段结束`, `阶段性收尾`, `做个好梦`, and `睡前整理一下`.
+3. Without an explicit mode, treat these preview signals and clear equivalents as `report`: `先整理看看`, `做个梦看看`, `睡前审阅一下`, `看看知识之间的关系`, `只出报告`, and `先别修改`.
+4. If both signal classes appear in one request, ask the user to choose a mode. Do not assume `apply`.
+5. A direct but otherwise unspecified invocation defaults to `report`.
+
+The modes have these effects:
+
+- `report` reads the shelf and returns a structured report. It creates no state marker and changes no knowledge or statement.
+- `apply` may add a missing statement or replace an explicitly contradicted statement. It never creates, edits, or deletes a regular Knowledge entry.
+
+Before every Hypatia CLI command, briefly state the goal, the exact command, why that query or mutation is appropriate, and the expected result. Use one-shot commands only; do not use `hypatia repl`.
+
+## Hypatia Conventions To Preserve
+
+Use the actual Statement fields and CLI terminology: `head`, `relation`, and `tail`. Do not describe them as fields named `subject`, `predicate`, or `object` in commands or reports.
+
+Prefer the relationship vocabulary already established by Hypatia's semantic-memory design:
+
+- `is_a` for a clear category relationship.
+- `refines` for a more precise form of an existing concept.
+- `extends` for an addition that builds on an existing concept.
+- `supersedes` for an explicit replacement of an older concept or decision.
+- `derivedFrom` for a clear provenance relationship.
+
+Preserve existing predicate spellings. `belongTo` and `summary` are operational relationships maintained by the memory system; do not reinterpret, delete, replace, or add semantic links to their message/session/summary endpoints. Likewise, do not reorganize archive metadata relationships such as `is_a archive`.
+
+Do not use a vague catch-all relationship such as `related_to` merely because two entries share words or a topic. Omit uncertain candidates.
+
+## Resolve The CLI And Snapshot Boundary
+
+1. Resolve the binary in this order: `hypatia` on `PATH`, `./target/debug/hypatia`, then `./target/release/hypatia`. Stop and report a concrete blocker if none exists.
+2. Set `SHELF` to the requested shelf or `default`.
+3. Record a UTC run-start timestamp before reading graph data. Format it as `YYYY-MM-DD HH:MM:SS`, which compares correctly with Hypatia's `created_at` values.
+4. Query the latest successful apply marker in the same shelf:
+
+```bash
+hypatia query '{"$knowledge":[["$contains","tags","hypatia-dream-run"]],"limit":1}' -s "<SHELF>"
+```
+
+A marker is a system-tagged Knowledge entry created by this skill after a successful `apply`. Its content contains a `processed_through` timestamp. Read that value, not the marker entry's `created_at`: a run can create statements after its snapshot begins, and using the marker creation time could skip concurrent new information.
+
+5. Define the collection interval as follows:
+
+- If a valid marker exists, use `processed_through < created_at <= run_started_at`.
+- If there is no valid marker, this is the first consolidation pass. Collect all pre-snapshot triples and knowledge entries.
+- A malformed marker is not a reason to guess. Report it and treat the run as a first pass unless the user supplies an explicit baseline.
+
+`report` mode must not advance this watermark. This lets a later `apply` reconsider the same proposed changes. Only a completed `apply` writes a marker.
+
+## Gather The Working Set
+
+Retrieve the complete pre-snapshot relationship graph. Use a large, explicit limit because the shelf is personal and the user requested no relationship-range cap:
+
+```bash
+hypatia query '{"$statement":[["$lte","created_at","<RUN_STARTED_AT>"]],"limit":10000}' -s "<SHELF>"
+```
+
+Retrieve the newly created triples with the collection interval. For a first pass, omit the lower-bound condition:
+
+```bash
+hypatia query '{"$statement":[["$and",["$gt","created_at","<BASELINE>"],["$lte","created_at","<RUN_STARTED_AT>"]]],"limit":10000}' -s "<SHELF>"
+```
+
+Also retrieve new Knowledge entries from the same interval. Exclude internal log, session, summary, and dream-marker entries by tag. For a first pass, omit the lower-bound condition:
+
+```bash
+hypatia query '{"$knowledge":[["$and",["$gt","created_at","<BASELINE>"],["$lte","created_at","<RUN_STARTED_AT>"],["$not",["$or",["$contains","tags","message"],["$contains","tags","session"],["$contains","tags","summary"],["$contains","tags","hypatia-dream-run"]]]]],"limit":10000}' -s "<SHELF>"
+```
+
+The new Knowledge set can include an unlinked node. It is eligible for one well-supported relationship to an older graph node, but only after its body and the prospective target's body have been read for disambiguation. Do not manufacture a relation solely to make an isolated node connected.
+
+For each potentially affected node, fetch its Knowledge entry by exact name and inspect its one-hop incident triples from the full graph. Read only the bodies needed to explain an entity match, source lineage, category, refinement, extension, supersession, or direct contradiction. Never use conversation text, session summaries, or system markers as semantic evidence.
+
+## Reason About Relationships
+
+Work from the newly added triples and eligible new Knowledge nodes toward the full existing graph. For every candidate, identify:
+
+- The exact new evidence: triple or Knowledge entry name and the relevant wording.
+- The supporting old graph context: exact triples and, when needed, the old node body.
+- The proposed triple in `(head, relation, tail)` form.
+- A confidence level and a short explanation of why that relation is more precise than its alternatives.
+
+Classify each outcome as exactly one of these:
+
+1. **Add**: a missing, non-duplicate triple is directly supported by the new evidence and the existing graph vocabulary.
+2. **Replace**: a specific old triple is directly contradicted by newer, unambiguous evidence. Name both triples. Prefer adding `supersedes` when the old idea remains historically useful; delete and replace only when the old relation itself is false.
+3. **No change**: evidence is duplicate, weak, ambiguous, historical rather than contradictory, or depends on a protected/system relation.
+
+A candidate must be high confidence before it may be applied. Similarity, shared tags, or lexical overlap alone are never high confidence.
+
+Before a replacement, inspect the old statement's `content`, `tr_start`, and `tr_end`. Do not apply a replacement when `tr_start` or `tr_end` is populated: the CLI cannot recreate temporal bounds. Also do not apply a replacement if the original statement metadata cannot be faithfully preserved through `statement-create`; report it instead.
+
+## Apply Changes
+
+In `report` mode, stop after producing the report. Do not write a marker.
+
+In `apply` mode, execute this sequence only after the analysis identifies high-confidence changes:
+
+1. Re-query every proposed old and new triple immediately before mutating. Skip stale plans, existing additions, and replacements whose source triple no longer matches the reviewed evidence.
+2. Before the first destructive deletion, export the shelf to a timestamped backup directory and report the destination. Use `hypatia export`; create the destination directory explicitly when needed.
+3. For a replacement, delete only the exact reviewed source triple, then create the exact reviewed replacement. Preserve `data`, positional `synonyms`, and `scopes` from the source statement when they apply. Never delete first if that metadata or a temporal bound cannot be preserved.
+4. For an addition, create only the exact reviewed triple. Do not create supporting nodes or generic fallback links.
+5. Re-query each created triple and every intended removal. If verification fails, stop, report the partial outcome and backup location, and do not create a watermark.
+
+After all intended changes verify, write one run marker in the same shelf:
+
+```bash
+hypatia knowledge-create "hypatia-dream-run-<UTC_COMPACT_TIMESTAMP>" \
+  -d "schema: 1
+mode: apply
+processed_through: <RUN_STARTED_AT>
+added: <COUNT>
+replaced: <COUNT>
+report: Hypatia Dream completed successfully" \
+  -t "system,hypatia-dream-run" \
+  -s "<SHELF>"
+```
+
+The marker is operational metadata, not semantic knowledge. Never attach a Statement triple to it or use it as relationship evidence.
+
+If no high-confidence graph changes exist, `apply` may still write the marker after reporting a verified no-op. This records that the interval has been reviewed without falsely claiming a graph mutation.
+
+## Required Report
+
+Return the report in this structure, in the user's language:
+
+```markdown
+# Hypatia Dream Report
+
+## Scope
+- Shelf: `<name>`
+- Mode: `report` or `apply`
+- Baseline: first pass, or `<processed_through>`
+- Snapshot boundary: `<run_started_at>`
+- Reviewed: `<new knowledge count>` Knowledge entries and `<new statement count>` new triples against `<total statement count>` existing triples
+
+## Relationship Findings
+### Add
+- `(head, relation, tail)` [high confidence]
+  Evidence: ...
+  Existing context: ...
+
+### Replace
+- `(old head, old relation, old tail)` -> `(new head, new relation, new tail)` [high confidence]
+  Evidence: ...
+  Rationale: ...
+
+### No Change
+- Item: ...
+  Reason: duplicate, insufficient evidence, protected system relation, or metadata/temporal safety restriction.
+
+## Outcome
+- Planned or applied additions: `<count>`
+- Planned or applied replacements: `<count>`
+- Skipped candidates: `<count>`
+- Backup: `<path>` or `not needed`
+- Watermark: `<processed_through>` written only after a verified `apply`, otherwise `unchanged`
+```
+
+Be concise but include every command that changed state and every exact triple it affected. Do not claim a relationship was corrected unless its post-mutation query verified the result.

--- a/skills/hypatia-dream/SKILL.md
+++ b/skills/hypatia-dream/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hypatia-dream
-description: "Run a deliberate, incremental Hypatia graph-consolidation pass at the end of a work period, like sleep-time knowledge organization. Trigger only for an explicit batch closeout or sleep-time request, not ordinary knowledge CRUD or a one-off triple. With no explicit --mode, treat these Chinese closeout signals as apply: '下班了', '收工了', '今天先到这', '本阶段结束', '阶段性收尾', '做个好梦', and '睡前整理一下'. Treat these as report-only: '先整理看看', '做个梦看看', '睡前审阅一下', '看看知识之间的关系', '只出报告', and '先别修改'. Analyze Statement triples as primary evidence, read Knowledge bodies only for disambiguation, then report or safely apply high-confidence relationship additions and corrections."
+description: "Run an incremental Hypatia graph-consolidation pass at a work-period boundary, like sleep-time knowledge organization. Trigger only for an explicit batch closeout or dream-time review, not ordinary knowledge CRUD, a one-off triple, or a lookup. Without an explicit --mode, these mean apply: '下班了', '收工了', '今天先到这', '本阶段结束', '阶段性收尾', '做个好梦', '睡前整理一下', 'done for the day', 'wrapping up', 'call it a night'. These mean report-only: '先整理看看', '做个梦看看', '睡前审阅一下', '看看知识之间的关系', '只出报告', '先别修改', 'just show me first', 'do not change anything yet'. Statement triples are the primary evidence; Knowledge bodies only disambiguate."
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob
 argument-hint: "[shelf] [--mode report|apply]"
@@ -21,8 +21,8 @@ Interpret the optional shelf name from the request; use `default` when it is omi
 Resolve the mode in this order:
 
 1. An explicit `--mode report` or `--mode apply` always wins.
-2. Without an explicit mode, treat these closeout signals and clear equivalents as `apply`: `下班了`, `收工了`, `今天先到这`, `本阶段结束`, `阶段性收尾`, `做个好梦`, and `睡前整理一下`.
-3. Without an explicit mode, treat these preview signals and clear equivalents as `report`: `先整理看看`, `做个梦看看`, `睡前审阅一下`, `看看知识之间的关系`, `只出报告`, and `先别修改`.
+2. Without an explicit mode, treat these closeout signals and clear equivalents as `apply`: `下班了`, `收工了`, `今天先到这`, `本阶段结束`, `阶段性收尾`, `做个好梦`, `睡前整理一下`, `done for the day`, `wrapping up`, and `call it a night`.
+3. Without an explicit mode, treat these preview signals and clear equivalents as `report`: `先整理看看`, `做个梦看看`, `睡前审阅一下`, `看看知识之间的关系`, `只出报告`, `先别修改`, `just show me first`, and `do not change anything yet`.
 4. If both signal classes appear in one request, ask the user to choose a mode. Do not assume `apply`.
 5. A direct but otherwise unspecified invocation defaults to `report`.
 
@@ -52,15 +52,29 @@ Do not use a vague catch-all relationship such as `related_to` merely because tw
 ## Resolve The CLI And Snapshot Boundary
 
 1. Resolve the binary in this order: `hypatia` on `PATH`, `./target/debug/hypatia`, then `./target/release/hypatia`. Stop and report a concrete blocker if none exists.
-2. Set `SHELF` to the requested shelf or `default`.
-3. Record a UTC run-start timestamp before reading graph data. Format it as `YYYY-MM-DD HH:MM:SS`, which compares correctly with Hypatia's `created_at` values.
+2. Set `SHELF` to the requested shelf or `default`, then confirm that shelf is connected before doing anything else:
+
+```bash
+hypatia list
+```
+
+Every Hypatia command fails when the target shelf is not connected, and the whole CLI fails at startup when any registered shelf uses the legacy DuckDB layout. Both are blockers to report, not conditions to work around.
+
+3. Record a UTC run-start timestamp before reading graph data:
+
+```bash
+date -u '+%Y-%m-%d %H:%M:%S'
+```
+
+SQLite's `'now'` is UTC, so this is the same clock Hypatia stamps with. Hypatia writes `created_at` as `%Y-%m-%d %H:%M:%f`, so stored values carry milliseconds (`2026-09-02 08:50:08.790`) and compare as TEXT. A second-resolution boundary is therefore slightly conservative, deliberately so: `created_at <= "2026-09-02 08:50:08"` excludes `2026-09-02 08:50:08.790`, and because the watermark is written at the same resolution, the next run's `created_at > "2026-09-02 08:50:08"` picks that row back up. Do not pad the boundary with `.999` and do not truncate stored values to close the apparent gap — either one reintroduces a real gap.
+
 4. Query the latest successful apply marker in the same shelf:
 
 ```bash
 hypatia query '{"$knowledge":[["$contains","tags","hypatia-dream-run"]],"limit":1}' -s "<SHELF>"
 ```
 
-A marker is a system-tagged Knowledge entry created by this skill after a successful `apply`. Its content contains a `processed_through` timestamp. Read that value, not the marker entry's `created_at`: a run can create statements after its snapshot begins, and using the marker creation time could skip concurrent new information.
+Query results are ordered by `created_at DESC`, so `limit:1` returns the most recent marker. A marker is a system-tagged Knowledge entry created by this skill after a successful `apply`. Its content contains a `processed_through` timestamp. Read that value, not the marker entry's `created_at`: a run can create statements after its snapshot begins, and using the marker creation time could skip concurrent new information.
 
 5. Define the collection interval as follows:
 
@@ -90,6 +104,8 @@ Also retrieve new Knowledge entries from the same interval. Exclude internal log
 hypatia query '{"$knowledge":[["$and",["$gt","created_at","<BASELINE>"],["$lte","created_at","<RUN_STARTED_AT>"],["$not",["$or",["$contains","tags","message"],["$contains","tags","session"],["$contains","tags","summary"],["$contains","tags","hypatia-dream-run"]]]]],"limit":10000}' -s "<SHELF>"
 ```
 
+`limit` is a hard cap, not a promise. Compare the returned row count with the limit for each of the three queries above. If they are equal, the result was truncated by `ORDER BY created_at DESC` and the graph in hand is incomplete. Stop, report the truncation as a blocker, and apply nothing: a relation can only be judged contradicted, duplicate, or missing against the whole graph, and a truncated read would let this skill "correct" a relationship whose supporting evidence was simply cut off.
+
 The new Knowledge set can include an unlinked node. It is eligible for one well-supported relationship to an older graph node, but only after its body and the prospective target's body have been read for disambiguation. Do not manufacture a relation solely to make an isolated node connected.
 
 For each potentially affected node, fetch its Knowledge entry by exact name and inspect its one-hop incident triples from the full graph. Read only the bodies needed to explain an entity match, source lineage, category, refinement, extension, supersession, or direct contradiction. Never use conversation text, session summaries, or system markers as semantic evidence.
@@ -111,7 +127,16 @@ Classify each outcome as exactly one of these:
 
 A candidate must be high confidence before it may be applied. Similarity, shared tags, or lexical overlap alone are never high confidence.
 
-Before a replacement, inspect the old statement's `content`, `tr_start`, and `tr_end`. Do not apply a replacement when `tr_start` or `tr_end` is populated: the CLI cannot recreate temporal bounds. Also do not apply a replacement if the original statement metadata cannot be faithfully preserved through `statement-create`; report it instead.
+Before a replacement, inspect the old statement's `content`, `tr_start`, and `tr_end`. A query result omits NULL columns entirely, so an absent `tr_start` or `tr_end` key means the statement has no temporal bound — not that the information is unavailable.
+
+`statement-create` accepts only `--data`, `--synonyms`, and `--scopes`. It cannot set `tags`, cannot set `format`, cannot set `figures`, and cannot recreate a temporal bound. Report instead of replacing whenever the source statement has any of these:
+
+- a populated `tr_start` or `tr_end`;
+- a non-empty `content.tags`;
+- a `content.format` other than `markdown`;
+- a non-empty `content.figures`.
+
+Otherwise the statement is eligible, and the replacement must carry over `content.data`, positional `content.synonyms`, and `content.scopes` from the source.
 
 ## Apply Changes
 
@@ -119,11 +144,41 @@ In `report` mode, stop after producing the report. Do not write a marker.
 
 In `apply` mode, execute this sequence only after the analysis identifies high-confidence changes:
 
-1. Re-query every proposed old and new triple immediately before mutating. Skip stale plans, existing additions, and replacements whose source triple no longer matches the reviewed evidence.
-2. Before the first destructive deletion, export the shelf to a timestamped backup directory and report the destination. Use `hypatia export`; create the destination directory explicitly when needed.
-3. For a replacement, delete only the exact reviewed source triple, then create the exact reviewed replacement. Preserve `data`, positional `synonyms`, and `scopes` from the source statement when they apply. Never delete first if that metadata or a temporal bound cannot be preserved.
-4. For an addition, create only the exact reviewed triple. Do not create supporting nodes or generic fallback links.
-5. Re-query each created triple and every intended removal. If verification fails, stop, report the partial outcome and backup location, and do not create a watermark.
+1. Re-query every proposed old and new triple immediately before mutating. Use the exact-key form, which matches on the `triple` primary key:
+
+```bash
+hypatia query '{"$statement":[["$triple","<HEAD>","<RELATION>","<TAIL>"]],"limit":1}' -s "<SHELF>"
+```
+
+Skip a stale plan, an addition that already exists, and a replacement whose source triple no longer matches the reviewed evidence.
+
+2. If the run plans any replacement, export the shelf to a timestamped backup directory before the first replacement step and report the destination. `export` creates the destination directory itself, so do not pre-create it, and pass the shelf name as the first argument:
+
+```bash
+hypatia export "<SHELF>" "<BACKUP_DIR>"
+```
+
+3. For an addition, create only the exact reviewed triple. Do not create supporting nodes or generic fallback links.
+
+```bash
+hypatia statement-create "<HEAD>" "<RELATION>" "<TAIL>" -s "<SHELF>"
+```
+
+`statement.triple` is unique, so creating a triple that already exists fails with `UNIQUE constraint failed: statement.triple`. That means the relationship is already recorded: treat it as a no-op, count it as skipped, and continue. It is not a run failure.
+
+4. For a replacement, **create the new triple first, verify it, and only then delete the source triple.** A replacement changes at least one of `head`, `relation`, and `tail`, so the two triples have different primary keys and can coexist for the moment in between. This ordering has no window in which the old relationship is already gone and the new one does not yet exist. Never delete first.
+
+```bash
+hypatia statement-create "<NEW_HEAD>" "<NEW_RELATION>" "<NEW_TAIL>" \
+  -d "<SOURCE_DATA>" --synonyms '<SOURCE_SYNONYMS_JSON>' --scopes "<SOURCE_SCOPES>" -s "<SHELF>"
+hypatia statement-delete "<OLD_HEAD>" "<OLD_RELATION>" "<OLD_TAIL>" -s "<SHELF>"
+```
+
+Carry the source metadata across exactly, and omit any flag whose source value is empty — `--synonyms ""` is a hard parse error, not an empty value. `--synonyms` takes the positional form `{"head":[...],"relation":[...],"tail":[...]}`. `--scopes` is comma-separated and a trailing comma means global scope, so source scopes `["project-a",""]` are reproduced as `--scopes "project-a,"` and `[""]` as `--scopes ","`.
+
+If the create fails, nothing has been lost: report it and leave the source triple untouched. If the create succeeds but the delete fails, stop and report both triples as present — the graph is consistent but now carries a duplicate relationship, and a person must decide.
+
+5. Re-query each created triple and every intended removal with the same `$triple` form. A created triple must come back; a removed triple must return `No results found.` Note that `statement-delete` exits non-zero with `not found` when the triple is already gone; that is an already-applied removal rather than a failure, but confirm it by query before continuing. If any verification fails, stop, report the partial outcome and the backup location, and do not create a watermark.
 
 After all intended changes verify, write one run marker in the same shelf:
 
@@ -141,6 +196,8 @@ report: Hypatia Dream completed successfully" \
 
 The marker is operational metadata, not semantic knowledge. Never attach a Statement triple to it or use it as relationship evidence.
 
+A marker is still an ordinary Knowledge entry: it is full-text indexed and vector-embedded like any other, so it will surface in the user's own `hypatia search` and `hypatia similar` results. Keep the body to the fields above for that reason — never store report prose, analysis, or candidate lists in it. This skill never deletes an old marker; only the most recent one is ever read.
+
 If no high-confidence graph changes exist, `apply` may still write the marker after reporting a verified no-op. This records that the interval has been reviewed without falsely claiming a graph mutation.
 
 ## Required Report
@@ -156,6 +213,7 @@ Return the report in this structure, in the user's language:
 - Baseline: first pass, or `<processed_through>`
 - Snapshot boundary: `<run_started_at>`
 - Reviewed: `<new knowledge count>` Knowledge entries and `<new statement count>` new triples against `<total statement count>` existing triples
+- Graph read: `<returned row count>` of `<limit>` rows, complete or truncated
 
 ## Relationship Findings
 ### Add

--- a/skills/hypatia-dream/evals/evals.json
+++ b/skills/hypatia-dream/evals/evals.json
@@ -1,0 +1,70 @@
+{
+  "skill_name": "hypatia-dream",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "在名为 research 的 Hypatia shelf 上做一次知识图谱睡眠整理。不要改动任何数据，只给我报告。这个 shelf 没有 hypatia-dream 水位；其中新增节点 'JSE Query Planner' 明确说明它细化了 'JSE Query Engine'，但目前缺少两者之间的关系。还包含一条 msg-123-4 belongTo session-123。",
+      "expected_output": "Resolve report mode, treat the run as a first pass, inspect the full statement graph and relevant Knowledge bodies, exclude the message/session operational relationship, and report a high-confidence candidate `(JSE Query Planner, refines, JSE Query Engine)` without executing any create, delete, export, or marker command.",
+      "files": [],
+      "expectations": [
+        "Defaults to report mode and schedules no state-changing command or watermark.",
+        "Treats the missing marker as a first pass with a fixed snapshot boundary.",
+        "Proposes (JSE Query Planner, refines, JSE Query Engine) with explicit evidence.",
+        "Excludes the belongTo message/session relationship from semantic consolidation."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "对默认 shelf 运行 hypatia-dream --mode apply。上次成功水位为 2026-03-01 09:00:00。新知识明确规定 'SQLite Storage' 已取代 'DuckDB Storage' 作为唯一结构化存储；图中仍有 `(Hypatia, uses, DuckDB Storage)`，该旧三元组没有时间范围，且 scopes 和 data 为空。请修正关系。",
+      "expected_output": "Use the marker's processed_through value and a fixed snapshot boundary, identify an explicit contradiction rather than a merely related concept, re-query the reviewed triple before mutation, export a backup before deletion, replace the stale triple with `(Hypatia, uses, SQLite Storage)`, verify both removal and creation, create a successful apply marker, and return the required report with exact changes and backup path.",
+      "files": [],
+      "expectations": [
+        "Uses the marker's processed_through value rather than its creation time.",
+        "Re-queries the exact old triple and exports a backup before the destructive delete.",
+        "Replaces exactly (Hypatia, uses, DuckDB Storage) with (Hypatia, uses, SQLite Storage).",
+        "Verifies the mutation and writes a successful apply marker only after verification."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "帮我做梦整理默认知识库，模式 report。新条目 'Database Notes' 和旧条目 'Distributed Systems' 都提到了 consistency，但没有明确的来源、分类、细化、扩展或替代关系；图中还存在一个时间范围不为空的 `(Storage, uses, DuckDB)` 三元组。",
+      "expected_output": "Report no semantic change for the lexical overlap, avoid adding a vague related_to triple, and explain that a time-bounded statement is not eligible for replacement through the current CLI because temporal bounds cannot be preserved.",
+      "files": [],
+      "expectations": [
+        "Does not add a related_to or other semantic triple from lexical overlap alone.",
+        "Does not replace the time-bounded Storage uses DuckDB triple.",
+        "Keeps report mode read-only and leaves the watermark unchanged."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "下班了。请对默认 Hypatia shelf 做个好梦。",
+      "expected_output": "Treat the two closeout signals as an explicit request for apply mode even though --mode is omitted; begin the safe apply workflow rather than returning a report-only plan.",
+      "files": [],
+      "expectations": [
+        "Selects apply mode without asking for confirmation.",
+        "Explains that the closeout wording is the mode signal, then follows the normal preflight, backup, verification, and watermark rules."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "先整理看看默认知识库，看看知识之间的关系；先别修改。",
+      "expected_output": "Treat the preview wording as report mode and make no graph or watermark mutation.",
+      "files": [],
+      "expectations": [
+        "Selects report mode from the preview signals.",
+        "Does not schedule statement mutations or watermark creation."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "本阶段结束了，但先别修改，帮我做个好梦。",
+      "expected_output": "Detect the conflicting apply and report signals, ask the user to choose a mode, and make no state change.",
+      "files": [],
+      "expectations": [
+        "Does not prioritize the closeout signal over the preview signal.",
+        "Requests a mode choice and performs no graph mutation or watermark update."
+      ]
+    }
+  ]
+}

--- a/skills/hypatia-dream/evals/evals.json
+++ b/skills/hypatia-dream/evals/evals.json
@@ -16,19 +16,19 @@
     {
       "id": 2,
       "prompt": "对默认 shelf 运行 hypatia-dream --mode apply。上次成功水位为 2026-03-01 09:00:00。新知识明确规定 'SQLite Storage' 已取代 'DuckDB Storage' 作为唯一结构化存储；图中仍有 `(Hypatia, uses, DuckDB Storage)`，该旧三元组没有时间范围，且 scopes 和 data 为空。请修正关系。",
-      "expected_output": "Use the marker's processed_through value and a fixed snapshot boundary, identify an explicit contradiction rather than a merely related concept, re-query the reviewed triple before mutation, export a backup before deletion, replace the stale triple with `(Hypatia, uses, SQLite Storage)`, verify both removal and creation, create a successful apply marker, and return the required report with exact changes and backup path.",
+      "expected_output": "Use the marker's processed_through value and a fixed snapshot boundary, identify an explicit contradiction rather than a merely related concept, re-query the reviewed triple with the $triple exact-key form before mutation, export a backup before the replacement, create `(Hypatia, uses, SQLite Storage)` first and verify it, only then delete `(Hypatia, uses, DuckDB Storage)`, verify the removal, create a successful apply marker, and return the required report with exact changes and backup path.",
       "files": [],
       "expectations": [
         "Uses the marker's processed_through value rather than its creation time.",
-        "Re-queries the exact old triple and exports a backup before the destructive delete.",
-        "Replaces exactly (Hypatia, uses, DuckDB Storage) with (Hypatia, uses, SQLite Storage).",
-        "Verifies the mutation and writes a successful apply marker only after verification."
+        "Re-queries the exact old triple and exports a backup before the replacement.",
+        "Creates (Hypatia, uses, SQLite Storage) BEFORE deleting (Hypatia, uses, DuckDB Storage), never the reverse order.",
+        "Verifies both the creation and the removal, and writes a successful apply marker only after verification."
       ]
     },
     {
       "id": 3,
       "prompt": "帮我做梦整理默认知识库，模式 report。新条目 'Database Notes' 和旧条目 'Distributed Systems' 都提到了 consistency，但没有明确的来源、分类、细化、扩展或替代关系；图中还存在一个时间范围不为空的 `(Storage, uses, DuckDB)` 三元组。",
-      "expected_output": "Report no semantic change for the lexical overlap, avoid adding a vague related_to triple, and explain that a time-bounded statement is not eligible for replacement through the current CLI because temporal bounds cannot be preserved.",
+      "expected_output": "Report no semantic change for the lexical overlap, avoid adding a vague related_to triple, and explain that a time-bounded statement is not eligible for replacement through the current CLI because statement-create cannot recreate temporal bounds. Note that the CLI itself never sets tr_start/tr_end, so this guard exists for statements written by other Hypatia clients.",
       "files": [],
       "expectations": [
         "Does not add a related_to or other semantic triple from lexical overlap alone.",
@@ -64,6 +64,28 @@
       "expectations": [
         "Does not prioritize the closeout signal over the preview signal.",
         "Requests a mode choice and performs no graph mutation or watermark update."
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "下班了，对默认 shelf 做个好梦。这个 shelf 很大：完整关系图查询返回的行数正好等于 10000 条上限。",
+      "expected_output": "Detect that the returned row count equals the query limit, treat the graph read as truncated rather than complete, and stop with a blocker report instead of applying any addition or replacement against a partial graph.",
+      "files": [],
+      "expectations": [
+        "Compares the returned row count against the limit and identifies the read as truncated.",
+        "Applies no statement mutation and writes no watermark.",
+        "Reports the truncation as a concrete blocker rather than proceeding on the rows it did receive."
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "对默认 shelf 运行 hypatia-dream --mode apply。新知识明确说明 'Parquet Export' 已取代 'CSV Export'；旧三元组 `(Pipeline, emits, CSV Export)` 没有时间范围，但它的 content.tags 是 [\"pipeline\",\"legacy\"]。",
+      "expected_output": "Recognize the contradiction but refuse to apply the replacement, because statement-create has no tags flag and the source statement's tags would be silently dropped. Report the candidate under No Change with the metadata-preservation reason and leave the graph unchanged.",
+      "files": [],
+      "expectations": [
+        "Does not delete or replace (Pipeline, emits, CSV Export).",
+        "Names the non-empty content.tags as the reason the statement is ineligible for replacement.",
+        "Reports the candidate rather than silently dropping it or silently losing the tags."
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Add the `hypatia-dream` skill for incremental, relationship-focused Hypatia graph consolidation.
- Add explicit closeout and preview phrases that select `apply` or `report` mode.
- Keep relation changes high-confidence and protect system and time-bounded statements.
- Sync the bundled `dsh-hypatia` skill copy and add evaluation scenarios.

## Validation

- Verified the source and bundled skill copies match.
- Validated `skills/hypatia-dream/evals/evals.json` with `jq empty`.
- Ran `git diff --check` on the committed patch.