### PR TITLE
feat: configurable PostgreSQL + pgvector backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +364,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -468,6 +488,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +621,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -660,6 +703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +750,24 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
 
 [[package]]
 name = "cxx"
@@ -867,6 +937,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,7 +976,7 @@ checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
 dependencies = [
  "arrow",
  "cast",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
  "libduckdb-sys",
@@ -951,6 +1033,12 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -1104,7 +1192,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1131,6 +1219,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1201,6 +1290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hypatia"
 version = "0.3.0"
 dependencies = [
@@ -1262,13 +1369,18 @@ dependencies = [
  "clap",
  "duckdb",
  "jieba-rs",
+ "native-tls",
  "ndarray",
  "ort",
+ "pgvector",
+ "postgres",
+ "postgres-native-tls",
  "rand 0.9.2",
  "rusqlite",
  "rustyline",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokenizers",
@@ -1741,7 +1853,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1781,6 +1893,15 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1827,6 +1948,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,7 +1986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2004,6 +2135,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2255,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2297,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
+dependencies = [
+ "bytes",
+ "postgres-types",
+]
 
 [[package]]
 name = "phf"
@@ -2196,6 +2378,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.10.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
@@ -2406,6 +2646,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,6 +2735,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2633,7 +2899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.11.0",
  "libsqlite3-sys",
@@ -2756,6 +3022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,6 +3133,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,6 +3235,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3212,12 +3506,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.2",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3363,10 +3707,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -3376,6 +3741,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3522,6 +3893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,6 +3917,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3665,6 +4054,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 
 [dependencies]
 duckdb = { version = "1", features = ["bundled"], optional = true }
-rusqlite = { version = "0.39", features = ["bundled", "functions"] }
+rusqlite = { version = "0.39", features = ["bundled", "functions", "backup"] }
 usearch = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -20,13 +20,19 @@ ndarray = "0.17"
 toml = "0.8"
 ureq = { version = "3", features = ["json"] }
 jieba-rs = "0.8"
+sha2 = "0.11"
+tempfile = "3"
+postgres = { version = "0.19", features = ["with-chrono-0_4", "with-serde_json-1"], optional = true }
+pgvector = { version = "0.4", features = ["postgres"], optional = true }
+postgres-native-tls = { version = "0.5", optional = true }
+native-tls = { version = "0.2", optional = true }
 
 [features]
 default = []
+postgres-backend = ["dep:postgres", "dep:pgvector", "dep:postgres-native-tls", "dep:native-tls"]
 # Read-side support for pre-0.2 duckdb shelves (data.duckdb). Enable only
 # when a legacy shelf still needs migrating; pulls the heavy duckdb build.
 legacy-migration = ["dep:duckdb"]
 
 [dev-dependencies]
-tempfile = "3"
 rand = "0.9"

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 "We can wander through the stacks of the Library of Alexandria, imagining the scrolls and the knowledge they contain. Its destruction is a warning: all we have is transient."——Alberto Manguel
 
-AI-oriented memory management system. Stores structured knowledge as a graph of **Knowledge** entries (nodes) and **Statement** triples (edges), queried via a custom JSON Search Expression (JSE) language. Built on SQLite FTS5 + DuckDB, with configurable embedding models (local ONNX or remote API) for semantic vector search.
+AI-oriented memory management system. Stores structured knowledge as a graph of **Knowledge** entries (nodes) and **Statement** triples (edges), queried via a custom JSON Search Expression (JSE) language. Uses SQLite + FTS5 + usearch by default, with an optional complete PostgreSQL + pgvector backend and configurable embedding models (local ONNX or remote API). See [PostgreSQL configuration and migration](docs/pgvector-backend.md).
 
 ## Features
 
 - **Knowledge Graph** -- Knowledge entries (named info points with tags) and Statement triples (subject-predicate-object with temporal ranges)
 - **JSE Query Engine** -- JSON-based query language compiling to parameterized SQL + FTS5, supporting `$and`, `$or`, `$not`, `$eq`, `$ne`, `$gt`, `$lt`, `$contains`, `$like`, `$content`, `$search`, `$quote`, `$triple`, `$k-hop`
-- **Dual-Database Storage** -- DuckDB for structured queries + vector search, SQLite FTS5 (Porter stemmer + multi-column BM25) for full-text search, auto-synchronized
-- **Configurable Vector Search** -- Local ONNX models (BGE-M3 default) or remote API (OpenAI-compatible) for semantic similarity search via DuckDB cosine distance
+- **Configurable Storage** -- SQLite + FTS5 + usearch, or PostgreSQL + JSONB + full-text search + pgvector, selected per shelf
+- **Configurable Vector Search** -- Local ONNX models (BGE-M3 default) or remote API (OpenAI-compatible) for semantic similarity search using cosine distance
 - **Synonyms** -- Per-entry synonym lists for knowledge, per-position (subject/predicate/object) synonyms for statements, indexed in FTS
 - **Shelf System** -- Named, connectable, exportable data directories for isolation
 - **CLI + REPL** -- Full command-line interface with interactive mode (rustyline)
@@ -193,7 +193,26 @@ Set the API key as an environment variable:
 export OPENAI_API_KEY="sk-..."
 ```
 
-### Configuration Reference
+### Storage Backend
+
+By default Hypatia uses SQLite + FTS5 + usearch. To use PostgreSQL + pgvector instead, build with `--features postgres-backend` and add `[storage]` to `shelf.toml`:
+
+```toml
+[storage]
+backend = "pgvector"
+
+[storage.postgres]
+url_env = "HYPATIA_POSTGRES_URL"
+schema = "hypatia_team_memory"
+
+[storage.vector]
+index = "hnsw"
+metric = "cosine"
+```
+
+See [docs/pgvector-backend.md](docs/pgvector-backend.md) for details on migration, TLS, HNSW dimension limits, and shared archives.
+
+### Embedding Configuration Reference
 
 | Field | Default | Description |
 |-------|---------|-------------|
@@ -221,7 +240,8 @@ export OPENAI_API_KEY="sk-..."
 | `hypatia statement-delete <subj> <pred> <obj>` | Delete a triple |
 | `hypatia search <query> [-c <catalog>] [--limit N]` | Full-text search |
 | `hypatia similar <query> [--limit N]` | Vector similarity search |
-| `hypatia backfill` | Generate embeddings for all entries |
+| `hypatia backfill [--reembed] [-s <shelf>]` | Generate embeddings for entries missing vectors (or regenerate all) |
+| `hypatia import <source> [-s <shelf>] [--reembed]` | Import an exported snapshot into an empty shelf |
 | `hypatia archive-store <file> [-n <name>] [-s <shelf>]` | Store a file in archives with auto-metadata |
 | `hypatia archive-get <name> [-o <output>] [-s <shelf>]` | Get an archive file path or copy it |
 | `hypatia archive-list [-s <shelf>]` | List all archive files |
@@ -321,30 +341,37 @@ src/
 ├── embedding/      # Embedding providers (ONNX local + remote API)
 ├── engine/         # JSE parser, AST, evaluator, SQL builder
 ├── model/          # Knowledge, Statement, Content, Query types
-├── service/        # Business logic (dual-write to DuckDB + SQLite)
-├── storage/        # DuckDB store, SQLite FTS5 store, shelf manager
+├── service/        # Business logic (CRUD + embedding writeback)
+├── storage/        # SQLite store, optional PostgreSQL store, shelf manager
 ├── lab.rs          # Top-level API facade
 ├── error.rs        # Error types
 ├── lib.rs          # Module declarations
 └── main.rs         # Entry point
 ```
 
-Each **shelf** is a directory containing `data.duckdb` (structured data), `index.sqlite` (FTS5 index), optional `shelf.toml` (embedding config), embedding model files, and an `archives/` directory for attachments. The service layer keeps both databases in sync via dual-write.
+Each **shelf** is a directory containing configuration (`shelf.toml`), attachment archives (`archives/`), and optionally embedding model files. The actual data lives in either:
+
+- **SQLite backend (default)**: `hypatia.sqlite` (structured data + FTS5 + JSON index + embedding BLOBs) and `vectors/` (rebuildable usearch ANN cache).
+- **PostgreSQL backend**: a configured PostgreSQL schema with JSONB, tsvector, and pgvector. The shelf directory still holds `shelf.toml` and `archives/` locally.
+
+The service layer delegates to the configured backend via the `ShelfBackend` abstraction.
 
 ## Archive Files
 
 Hypatia supports storing archive files (images, PDFs, data, etc.) alongside knowledge entries. Files are stored in the shelf's `archives/` directory and referenced via the `archive://` convention in knowledge content.
 
 ```
-~/.hypatia/default/
-├── data.duckdb
-├── index.sqlite
+~/.hypatia/default/                 # SQLite backend (default)
+├── hypatia.sqlite
+├── vectors/
 ├── shelf.toml
 └── archives/
     └── euclid/
         ├── fig_1_1.png
         └── fig_1_2.svg
 ```
+
+PostgreSQL-backed shelves omit `hypatia.sqlite` and `vectors/`; the directory still contains `shelf.toml` and `archives/`.
 
 ### Commands
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,7 +14,12 @@ Hypatia 的知识由两大类组成，
 
 Hypatia 的知识通过 shelves 分组，提供一个默认的 shelves，允许用户导入、导出和引用不同的 shelves。
 
-一个 Shelves 是一个目录，每个目录包含 `hypatia.sqlite`（唯一源真相：knowledge/statement 表 + docs 锚点 + json_index 倒排 + FTS5 + 向量 BLOB 列）、`vectors/`（usearch ANN 快照，可重建缓存）、可选的 `shelf.toml`（嵌入模型配置）和嵌入模型文件。0.2 起不再使用 duckdb。
+一个 Shelves 是一个目录，每个目录包含配置、附件和按后端选择的数据存储：
+
+- **SQLite 后端（默认）**：`hypatia.sqlite`（唯一源真相：knowledge/statement 表 + docs 锚点 + json_index 倒排 + FTS5 + 向量 BLOB 列）、`vectors/`（usearch ANN 快照，可重建缓存）。
+- **PostgreSQL 后端**：数据库由 `shelf.toml` 中的 `[storage]` 配置指定，使用 PostgreSQL + JSONB + tsvector + pgvector 管理数据；附件仍保留在 shelf 本地 `archives/`。
+
+可选的 `shelf.toml` 同时包含 `[storage]`（后端选择）和 `[embedding]`（嵌入模型配置）。0.2 起不再使用 duckdb。
 
 Hypatia 面向局部环境，因此数据管理也遵循简单原则，例如 knowledge 直接保存 name 作为主键，statement 中直接保存三元组的可读性形式 `head, relation, tail` 作为主键。content 是一个 json 对象，默认总会包含：
 
@@ -72,12 +77,44 @@ pooling = "mean"             # "mean" / "cls" / "last_token"
 
 默认使用 BAAI/bge-m3 (568M params, 1024d, mean pooling)。也支持 EmbeddingGemma-300M、gte 系列、Jina v5 等模型，以及 OpenAI 兼容的远程 API。
 
+### 存储后端配置
+
+通过 `shelf.toml` 的 `[storage]` 段选择后端，默认使用 SQLite：
+
+```toml
+[storage]
+backend = "sqlite"   # 默认
+```
+
+也可选择 PostgreSQL + pgvector 作为完整后端：
+
+```toml
+[storage]
+backend = "pgvector"
+
+[storage.postgres]
+url_env = "HYPATIA_POSTGRES_URL"   # 或 url = "postgresql://..."
+schema = "hypatia_team_memory"
+connect_timeout_seconds = 5
+statement_timeout_ms = 30000
+
+[storage.vector]
+index = "hnsw"   # 或 "none" 使用精确扫描
+metric = "cosine"
+```
+
+PostgreSQL 后端需要以 `--features postgres-backend` 编译；附件仍保留在 shelf 本地 `archives/` 目录，不会随数据库自动共享。详见 [docs/pgvector-backend.md](pgvector-backend.md)。
+
 ### 全文索引与 JSON 倒排
 
-全文检索沿用 SQLite FTS5（jieba 预分词 + porter），锚定统一文档表 `docs(id, catalog, key)`；
+**SQLite 后端**：全文检索使用 SQLite FTS5（jieba 预分词 + porter），锚定统一文档表 `docs(id, catalog, key)`；
 JSON 字段查询走路径树倒排 `json_index(doc_id, path, kind, value, array_index)`，
 支持 $has（成员）、$content（键值）、$json-contains（@> 结构包含，倒排召回 + json_contains UDF recheck）；
 向量检索由外置 usearch 快照承担（可从 embedding BLOB 列重建），详见 docs/sqlite-refactor-plan.md。
+
+**PostgreSQL 后端**：全文检索使用 PostgreSQL `tsvector` + `simple` 配置 + Jieba 预分词；
+JSON 字段查询使用 JSONB 路径与派生 `tokens` JSONB；向量检索使用 pgvector（HNSW 或精确扫描）。
+两后端的 FTS 排名、词干处理和分数语义可能存在差异，跨后端部署时应注意。
 
 ## 命令行
 
@@ -118,7 +155,7 @@ Hypatia 的 JSE 指令包含：
 - $or 会转化成 SQL where 条件中的 or
 - $not 会转化成 SQL where 条件中的 not
 - $search 会转化成 SQLite FTS 数据中的查询，它始终在 $knowledge 或 $statement 内部使用，与 $and、$or 等指令一致，不单独传入 opts 参数，而是遵循外部的 opts 参数。$search 的产物是对应的子查询，这些子查询限制 knowledge 的 name 或 statement 的 head、relation、tail 匹配从 FTS 搜索到的 key
-- $similar 语义向量搜索，将查询文本编码为向量后通过 DuckDB cosine distance 检索最相似的条目
+- $similar 语义向量搜索，将查询文本编码为向量后通过 SQLite usearch 或 PostgreSQL pgvector 的 cosine distance 检索最相似的条目
 - $eq 对应等于
 - $ne 对应不等于
 - $gte 对应 大于等于
@@ -132,7 +169,7 @@ Hypatia 的 JSE 指令包含：
 - $k-hop 图遍历查询，基于 statement triples 做 k 跳递归 CTE，探索实体间的关系路径
 - $has 数组/标量成员精确匹配（倒排索引）；$json-contains 结构包含（倒排召回 + json_contains UDF recheck）
 - $quote 用于封装对查询的延迟解释，对应 LISP 语言的 quote 形式
-- 以上针对 duckdb 数据集的查询也包含可选的 opts 字典，其中包含
+- 以上针对 SQLite 或 PostgreSQL 数据集的查询也包含可选的 opts 字典，其中包含
   - catalog
   - offset
   - limit

--- a/docs/pgvector-backend-analysis.md
+++ b/docs/pgvector-backend-analysis.md
@@ -1,0 +1,269 @@
+# 可配置 PostgreSQL + pgvector 后端需求分析
+
+## 1. 结论与已确认范围
+
+可以在保留现有后端的前提下，增加由配置选择的完整 PostgreSQL + pgvector 后端。用户已确认：PostgreSQL 接管知识、三元组、结构化查询、全文检索和向量存储；不是仅把向量从 SQLite 分离到 PostgreSQL。
+
+建议提供两个完整实现：
+
+- `sqlite`：现有 SQLite + FTS5 + JSON 路径索引 + usearch，仍为缺省后端。
+- `pgvector`：PostgreSQL + JSONB + PostgreSQL 全文检索 + pgvector。此名称代表完整数据库后端，pgvector 本身只是 PostgreSQL 的向量扩展。
+
+沿用每个 shelf 的 `shelf.toml`，新增 `[storage]`。一个 shelf 对应一个后端，同一进程可连接使用不同后端的多个 shelf。没有新配置时，旧 shelf 按原方式打开。显式选择 PostgreSQL 后，连接或配置失败必须报错，不能静默回退 SQLite。
+
+完整后端接入需要覆盖读写接口、存储生命周期、迁移及检索能力。JSE 的结构化条件可以直接对等编译为 PostgreSQL JSONB 查询，保留现有 Parser/AST 并抽取 SQL 方言层即可；少数 SQLite 边界行为在方言层局部适配。主要工作量集中在完整存储接口、导出与迁移、写入一致性，以及全文检索等能力的适配。本文只交付分析与设计建议，没有实现后端或执行数据库变更。
+
+## 2. 当前实现及证据
+
+以下事实基于当前工作区源代码，而非历史设计文档。链接行号是本次检查时的位置。
+
+| 事实 | 源码依据 | 对方案的影响 |
+| --- | --- | --- |
+| 默认使用 rusqlite 与 usearch；DuckDB 只在 `legacy-migration` feature 中启用 | [Cargo.toml](../Cargo.toml) | 应保留 SQLite 默认构建和旧数据迁移路径 |
+| `Storage` 只有 SQL 查询、全文检索、语义检索、图遍历四类读方法 | [storage/mod.rs](../src/storage/mod.rs#L38) | 不能仅新增 `impl Storage for PgStore` 就覆盖所有命令 |
+| `OpenShelf.store` 固定为 `SqliteStore`，还直接持有向量文件索引 | [shelf_manager.rs](../src/storage/shelf_manager.rs#L10) | 后端选择需进入 shelf 打开流程，usearch 生命周期需封装到本地后端 |
+| CRUD 服务直接调用 `shelf.store`，再单独生成和写入向量 | [knowledge.rs](../src/service/knowledge.rs#L14)、[statement.rs](../src/service/statement.rs#L16) | 需统一写接口，并定义内容与向量的一致性 |
+| Lab 也直接读取 store，批量补向量调用 SQLite 风格方法 | [lab.rs](../src/lab.rs#L68)、[lab.rs](../src/lab.rs#L239) | 适配范围包括业务入口与维护流程 |
+| `knowledge` / `statement` 存 JSON 文本和 embedding BLOB；`docs`、FTS5、`json_index` 为辅助结构 | [sqlite_store.rs](../src/storage/sqlite_store.rs#L27) | PostgreSQL 可保留业务模型，辅助索引无需照搬 |
+| `SqlBuilder` 使用 `?` 参数；operators 生成 JSON1 / json_index SQL；evaluator 还直接拼接查询 | [sql_builder.rs](../src/engine/sql_builder.rs#L3)、[operators.rs](../src/engine/operators.rs#L90)、[evaluator.rs](../src/engine/evaluator.rs#L192) | 方言依赖不只在 SqlBuilder |
+| 配置目前只解析 `[embedding]`，文件读取或 TOML 解析失败会使用默认值 | [config.rs](../src/embedding/config.rs#L488) | 新存储配置必须使用返回 Result 的严格加载器 |
+| registry 保存 shelf 名称到本地目录的映射；默认 shelf 固定来自 home 下的 `.hypatia/default` | [shelf_registry.rs](../src/storage/shelf_registry.rs)、[shelf_manager.rs](../src/storage/shelf_manager.rs#L320) | 可继续以本地目录承载远端 shelf 的连接配置 |
+| 导出直接复制 SQLite 文件、vectors 和 archives | [shelf_manager.rs](../src/storage/shelf_manager.rs#L453) | PostgreSQL 必须新增逻辑导出路径 |
+
+现有语义检索优先 usearch，失败或无命中时会走 SQLite BLOB 的 Rust 暴力 kNN。这里的回退属于同一后端内部的索引策略，不应扩展为 PostgreSQL 失败后切换数据源。
+
+## 3. 配置与启动设计
+
+下面全部是建议新增的配置，当前版本尚不支持。
+
+保持默认后端：
+
+```toml
+[storage]
+backend = "sqlite"
+```
+
+选择 PostgreSQL：
+
+```toml
+[storage]
+backend = "pgvector"
+
+[storage.postgres]
+url_env = "HYPATIA_POSTGRES_URL"
+schema = "hypatia_team_memory"
+connect_timeout_seconds = 5
+statement_timeout_ms = 30000
+
+[storage.vector]
+index = "hnsw"
+metric = "cosine"
+
+[embedding]
+provider = "local"
+model = "BAAI/bge-m3"
+dimensions = 1024
+```
+
+数据库连接串通过指定环境变量读取，密码不写入仓库或导出文件；TLS 参数由连接配置及驱动实际支持的 TLS 实现共同处理，不能只写一个 `sslmode` 就认为已经实现证书验证。embedding provider 与存储后端独立，远程 embedding 也可以配合本地 SQLite，反之亦然。
+
+建议统一加载成 `ShelfSettings { storage, embedding }`，保留现有路径模型的职责，不继续让 embedding 模块拥有完整 shelf 配置的解析入口。规则如下：
+
+1. 没有 `shelf.toml` 或没有 `[storage]` 时，选择 SQLite。默认 shelf 的配置位置为 `~/.hypatia/default/shelf.toml`；其他 shelf 在各自目录。
+2. 已存在的文件不可读、TOML 非法、backend 未知、PostgreSQL 必填项缺失均报配置错误。存储配置拼写错误不能变成默认本地写入。明确记录：非法旧配置以前可能被忽略，严格加载后会暴露错误。
+3. 首期仅在连接 shelf 时加载配置。修改文件后通过重新连接或重启生效，不做运行中的自动切换。
+4. 先解析和验证配置，再创建对应后端资源。PostgreSQL shelf 不创建或迁移 `hypatia.sqlite`，也不初始化 `vectors/`。
+5. 连接时验证扩展、schema 版本、embedding 模型标识、维度和距离类型。缺扩展或元数据不匹配要明确提示处理方法。
+6. PostgreSQL 不可用时，默认 shelf 启动失败应可诊断；非默认 shelf 可保留当前恢复失败后标记未连接的模式，但对其执行命令必须明确失败。
+
+建议首期按 shelf 配置，不再引入全局存储默认值和 CLI 覆盖优先级。现有 registry 仍保存目录，不保存连接密码。`connect <path>` 仍可使用：远端 shelf 的这个 path 表示本地配置及附件目录。
+
+## 4. 存储抽象与模块边界
+
+建议保留 `OpenShelf` 作为 shelf 上下文，把具体后端状态移入实现内部：
+
+```text
+CLI / REPL / Lab
+        |
+CRUD Services + JSE Parser / Evaluator / SQL Dialect
+        |
+OpenShelf { settings, embedder, backend }
+        |
+        +-- LocalBackend { SqliteStore, VectorIndexes }
+        |       SQLite + FTS5 + json_index + usearch
+        |
+        +-- PostgresBackend { client, schema, metadata }
+                PostgreSQL + JSONB + tsvector + pgvector
+```
+
+面向领域操作定义对象安全的后端接口，具体方法签名在实现时根据当前模型收敛：
+
+| 接口组 | 应覆盖的操作 |
+| --- | --- |
+| 数据读写 | knowledge / statement 的创建、读取、更新、删除，原有重复键和不存在错误语义 |
+| 查询 | 执行对应方言的参数化查询、全文检索、接收向量的相似度检索、k-hop、未归纳知识查询 |
+| embedding | 分页枚举缺失或过期向量、带内容版本条件写回、统计状态 |
+| 生命周期 | 检查后端能力和版本、初始化或升级 schema、导出、重建派生索引、显式 flush |
+
+`OpenShelf` 或服务层继续负责调用 embedding provider；后端只接收向量及关联元数据，数据库连接内部不执行模型推理。usearch 的增删、快照及重建全部留在 LocalBackend 内部。PG 的向量索引由数据库维护，不能要求它模拟本地 `vector_upsert` / `save_vector_indexes` 文件操作。
+
+推荐 `Box<dyn ShelfBackend>` 作为边界，必要时拆分读写与维护 trait；只有两个实现时，内部用 enum 分派也可行。关键是业务层不再依赖公开的 `SqliteStore` 或 `rusqlite::Connection`。已有基于 `Storage` 的 evaluator mock 可分阶段适配。若已有外部 Rust 用户依赖 `OpenShelf.store`，应将其列为库 API 兼容性变化，不能因为 CLI 不变就认为完全无破坏。
+
+当前项目以同步调用为主，首期优先评估同步 `postgres` 驱动及 `pgvector` Rust 类型适配。可在 PG 实现内部封装客户端可变借用，避免为新增后端把 CLI 全面异步化。连接池依据实际并发需求引入；目前每个 shelf 的连接恢复会使连接数随 shelf 数增长，应设超时并考虑后续惰性连接。
+
+建议使用可选 Cargo feature `postgres-backend`：默认构建不拉取 PG 依赖；发布支持版包含该 feature 后，用户仅改配置即可选择两种后端。未编译该能力却配置 `pgvector` 时，明确报“当前二进制不支持”。需同时交付 feature 构建与不带 feature 的回归验证。
+
+## 5. JSE 直接对等编译为 JSONB 查询
+
+JSE 的结构化查询可以直接映射到 PostgreSQL SQL 与 JSONB 原生操作符。推荐保留现有 Parser、AST 和 evaluator 的查询流程，在 operators、SqlBuilder 及特殊查询生成处抽取方言接口，分别生成 SQLite 和 PostgreSQL 的参数化 SQL。当前两个后端的需求不以新增 QueryPlan 或另一套类型化条件树为前提；未来出现查询优化需求时再评估。
+
+### 5.1 常见查询的直接映射
+
+| JSE 查询意图 | PostgreSQL 生成形式 |
+| --- | --- |
+| 普通列相等或大小比较 | `name = $1`、`created_at >= $1` |
+| JSON 字符串字段读取 | `content ->> 'format'` |
+| JSON 嵌套路径读取 | `content #> $1::text[]`；文本值使用 `#>>` |
+| 字符串数组包含元素 | `(content -> 'tags') ? $1::text` |
+| 字符串数组包含任一元素 | `(content -> 'tags') ?\| $1::text[]` |
+| JSON 结构包含 | `content @> $1::jsonb` |
+| 与、或、非 | `AND`、`OR`、`NOT` |
+
+表中的数组存在操作符针对字符串元素；其他标量类型按 JSE 的类型契约生成相应表达式。动态 JSON 路径使用参数绑定，静态列名由已验证的字段映射生成。
+
+例如“tags 包含 rust，且 format 为 markdown”，可以生成以下查询（示例省略 schema 限定）：
+
+```sql
+SELECT name, content, created_at
+FROM knowledge
+WHERE (content -> 'tags') ? $1::text
+  AND content ->> 'format' = $2::text
+ORDER BY created_at DESC
+LIMIT $3 OFFSET $4;
+```
+
+参数依次为 rust、markdown、limit 和 offset。PostgreSQL 直接使用 JSONB 查询，无需复制 SQLite 的 json_index 辅助表。生成 SQL 时由方言层分配占位符和参数类型，不对已生成的 SQLite SQL 做文本替换。
+
+### 5.2 局部兼容事项
+
+以下是现有 SQLite 行为和数据表示的局部边界，适合在方言层处理并用对照用例验证，不构成引入新查询架构的理由：
+
+- 参数：SQLite 的 `?` 与 PG 的 `$1`、`$2`；类型由编译器指定，尤其 JSONB、时间、数值和 LIMIT/OFFSET。不能盲目替换问号，PG 本身也存在 `?` JSONB 运算符。
+- JSON 路径：JSON1 与 JSONB 提取方式不同；字段路径仍应验证并作为值绑定，schema 等标识符要严格验证及正确引用。
+- 数值比较：当前 SQLite `CAST(... AS REAL)` 对非法文本的行为与 PG 强制类型转换不同。需针对数字、数字字符串、非数字、缺失、null 定义兼容规则及测试，不能让查询因一条非数值内容整批失败。
+- `$contains`、`$has`：现有 membership 使用字符串 token，会模糊部分 JSON 类型；PG 的 JSONB 运算符有自身类型规则，不能直接假设相同。LIKE 的大小写、通配符和转义也要逐项测试。
+- `$json-contains`：优先利用 JSONB 包含查询，但当前 Rust `json_contains` 与 PG `@>` 并非所有边界都相同，例如数组包含标量。首期用对照用例决定兼容 SQL 或显式限制，不能依据代码注释宣称完全等价。
+- `Content.data` 是字符串，即使 `format=json` 也不是内嵌对象。PG JSONB 保存整个 Content 后，`data.foo` 仍需受控解析内部字符串，不能直接写成普通嵌套对象访问。可维护经验证的派生 JSONB payload，保持原始 data 字符串不变。
+- `$not-summaried` 的关联查询目前写在 evaluator，需一并纳入方言层或后端实现，不能只改通用 SqlBuilder。
+- `$k-hop` 使用递归 CTE；SQLite 允许的 `GROUP BY triple` 加裸列选择不能直接用于 PG。用最小深度聚合后关联原表或窗口函数返回结果，保留关系过滤、去重和深度边界；对环路及高分支图设置上限或执行超时。
+
+此外，当前 JSE 的 `$similar` / `$search` 是先取候选 key，再做普通查询并按 `created_at DESC` 排序。这与“过滤后取相似度 top-k”并不相同，也不会天然保留距离排序。首期按既有 JSE 行为做兼容验收；若需要过滤下推、混合检索或距离排序，作为明确的查询语义升级单独设计，避免 PG 后端悄悄改变同一个表达式的含义。
+
+## 6. PostgreSQL 数据与索引设计
+
+### 6.1 shelf 隔离
+
+首期推荐一 shelf 一 schema，配置中显式给出 schema，数据库可共享。业务主键因此无需全面增加 `shelf_id`，不同 shelf 可以使用不同向量维度。每个 schema 保存版本与 embedding 元数据，两个客户端只有显式使用同一数据库/schema 才共享数据。不要直接以本地路径或可随意变更的 shelf 显示名推导远端身份。
+
+schema 是命名与数据组织边界，不自动等同安全隔离。多用户部署须搭配数据库角色和 schema 权限。大量 shelf 的集中托管可后续评估共享表加 shelf_id、分区及 RLS，首期不引入该复杂度。所有 SQL 使用明确 schema 限定，避免连接复用时 search_path 导致串库。
+
+### 6.2 表结构
+
+保留 `knowledge(name, content, created_at)` 和 `statement(triple, head, relation, tail, content, created_at, tr_start, tr_end)` 的逻辑模型和键编码。建议 content 为 JSONB，embedding 为允许空值的 `vector(n)`，业务表带稳定内部文档 ID 以支持现有全文检索的 id 字段。两个 catalog 中的 id 不必视为全局唯一，对外身份使用 catalog + key。
+
+为并发和补向量增加内容版本或哈希、embedding 对应版本以及模型元数据。表内 vector 可为空，使无模型时的普通 CRUD 仍可用。FTS 所需 tsvector 及字段权重在写事务中维护；PG 不必复制 SQLite 的 `docs_fts`、`json_index` 结构。
+
+时间方面，当前 Rust 使用 `NaiveDateTime`，SQLite 用文本表示时间。首期可使用 `timestamp without time zone` 并显式约定系统时间为 UTC，以保持模型及序列化契约；不要直接切成 TIMESTAMPTZ 却遗漏 Rust 类型和输入时区的调整。
+
+建议索引：业务主键和创建时间 B-tree；三元组 head/relation/tail 及经查询验证有用的组合索引；JSONB GIN；tsvector GIN；各业务表的 embedding HNSW。不是每个索引都要无条件建立，应通过真实查询计划和写入成本确认。
+
+### 6.3 向量检索
+
+示意 SQL（假定 schema、表、扩展均已初始化，维度为 1024；不是完整 migration）：
+
+```sql
+CREATE INDEX knowledge_embedding_hnsw
+ON hypatia_team_memory.knowledge
+USING hnsw (embedding vector_cosine_ops);
+
+SELECT name, content, embedding <=> $1::vector AS distance
+FROM hypatia_team_memory.knowledge
+WHERE embedding IS NOT NULL
+ORDER BY embedding <=> $1::vector
+LIMIT $2;
+```
+
+沿用余弦距离，距离越小越相似。查询直接按距离运算符升序排序并限制数量，避免用变换后的相似度表达式排序妨碍索引匹配。HNSW 是近似检索，小规模数据可使用精确扫描；比较结果时用精确距离作为基线。
+
+维度来自 embedding 配置，在 schema 元数据与列类型中验证，避免再配置一个相互矛盾的维度值。还要记录模型身份：相同维度的不同模型不能混用。模型或维度改变必须走显式重嵌入与切换流程，不能仅改 TOML 后继续写入。拒绝 NaN、Infinity、错误维度，并明确零向量处理策略。
+
+pgvector 的可存储维度与特定类型 ANN 索引支持的维度上限不同。对默认 1024 维方案进行支持验证；远端大维度模型必须按选定扩展版本检查限制，不可直接承诺所有 embedding 配置都能建立 HNSW。halfvec、降维或其他索引策略涉及精度与行为变化，不能自动启用。
+
+如果后续把过滤条件下推到 ANN 查询，需要测试选择性过滤造成不足 k 条的问题，结合候选扩张、支持版本的 iterative scan 或精确查询解决，并用 EXPLAIN 验证执行路径。
+
+## 7. 全文检索与返回格式
+
+现有 FTS5 使用 porter/unicode61，中文通过 Jieba 预分词；key/data/tags/synonyms 的 BM25 权重为 10/1/5/3。PG 可复用 `Content.fts_fields` 和中文分词，再生成带权 tsvector 与 GIN 索引。
+
+首期建议先以 `simple` 文本配置验证中文及中英混合召回；英语词干、分词和权重需专项对照。PostgreSQL 原生 ts_rank/ts_rank_cd 不等于 FTS5 BM25，不能承诺排名或分数逐项一致。若要延续 rank 越小越优的接口，可返回 PG 评分的负值并按升序排列，但这只统一方向，不构成跨后端分数校准。
+
+需要验收空查询、标点、中文、多词 AND/OR、key/tags/synonyms、catalog 过滤和分页。不要把 FTS5 的清洗函数原封不动当作 PG tsquery 编译器。
+
+返回格式建立逐命令契约：CRUD/JSE 的 Content、全文检索 content、相似检索的 name/triple/distance、时间字段和错误类型。当前 ANN 与暴力 fallback 对 content 存在对象/字符串差异，应记录并通过公共转换层有计划地统一，避免把已有不一致误当 PG 特性。`QueryResult.total_count` 当前为本次返回行数，不应未经说明改为全量匹配数。
+
+## 8. 事务、一致性与故障行为
+
+现有内容写入后才生成向量，不能假设当前业务已经拥有“内容和 embedding 一次原子提交”。完整 PG 后端可以避免跨数据库双写，但仍要处理模型调用与事务的边界。
+
+建议内容与其 FTS 派生数据在一个事务中提交；更新内容时，同时使旧向量失效并标记待补。模型推理放在事务之外，生成后通过内容版本或哈希进行条件更新，只有内容仍匹配时才安装向量，防止慢请求覆盖新内容。删除内容及所有数据库派生记录在同一事务完成。
+
+无模型时保留普通 CRUD 能力，并使语义检索报模型不可用；模型网络错误、向量写回失败或维度不符需要返回可诊断状态。明确区分“正文已经保存但向量待补”与“正文未保存”，避免调用方盲目重试创建。索引维护与补向量应可重入，不能用进程退出时的 Drop 承担 PG 提交。
+
+schema 迁移应有版本表、事务边界及并发迁移锁；扩展由具备权限的管理员预先安装，应用连接阶段检查。数据库事务失败要回滚；连接断开后的写重试必须考虑提交结果未知的情况，不能一律自动重试非幂等操作。
+
+## 9. 切换、迁移、导出与附件
+
+修改 backend 只改变连接目标，不迁移数据。原有 SQLite 文件不会自动出现在 PG；切回 SQLite 也只能看到本地原有内容，不包含切换后在 PG 新增的数据。文档和 CLI 提示必须明确这一点。
+
+建议增加后端中立的逻辑迁移/导出能力，下面是流程建议，不是现有命令：
+
+1. 对源 shelf 建立一致性快照或暂停写入，保存可恢复备份。SQLite 导出应使用 backup API 或正确的快照流程，当前直接复制文件不能直接作为并发/WAL 场景的一致性保证。
+2. 初始化独立目标 schema，导入业务键、Content、时间、三元组、有效向量和模型元数据，不复制 usearch 文件。旧数据缺少可信模型身份时，不猜测模型，选择重新生成向量或由迁移配置明确指定并验证。
+3. 分批导入并记录进度；先导数据再建大索引。明确重复键冲突策略，首次迁移推荐目标为空，避免隐式覆盖。
+4. 校验行数、主键集合、规范化内容校验和、时间、向量维度及附件引用，再运行查询对照。
+5. 校验通过后才修改源目录的连接配置；保留原库作为切换点备份。切换后的回退若需保留新写入，应先反向迁移，单纯改回配置不是无损回滚。
+
+PostgreSQL 导出可采用一致性事务下的版本化逻辑包：manifest、knowledge/statement 记录、向量与模型信息、附件。连接密码不进入包；恢复时由操作者提供目标连接配置。现有 SQLite 导出格式需要继续支持，不能让旧 shelf 无法导入。
+
+现有 figures 引用 `archive://` 本地文件。本文建议首期 PostgreSQL 只接管数据库内容，`archives/` 仍归 shelf 本地目录管理，导出时随包复制。多客户端共享 PG 并不会自动共享附件；跨机器使用需部署共享附件目录，或后续独立引入对象存储。这是明确的首期范围建议，并非用户已经确认的附件托管要求。
+
+## 10. 实施拆分与验收
+
+| 阶段 | 主要产出 | 完成条件 |
+| --- | --- | --- |
+| 1. 固定契约与配置 | 统一 ShelfSettings，缺省兼容，明确查询/返回/错误语义 | 旧合法 shelf 配置可继续运行；非法 storage 配置报错 |
+| 2. 封装本地实现 | ShelfBackend、LocalBackend，清理 service/Lab/manager 的具体依赖 | 本地 CRUD、查询、向量、导出回归通过 |
+| 3. 增加 SQL 方言层 | 保留 Parser/AST，直接生成 JSONB 查询，适配特殊查询 | 常见操作映射与局部边界对照通过；PG 不接收 SQLite SQL |
+| 4. PostgreSQL 实现 | schema migration、CRUD、JSONB、FTS、图查询、pgvector | 在真实 PG + 扩展实例上通过后端契约测试 |
+| 5. 运维与迁移 | 导出导入、补向量、配置切换说明、诊断和发布构建 | 完整迁移及切回演练、默认构建与支持版均可用 |
+
+主要工作重点为完整读写接口、生命周期与迁移、写入一致性及全文检索适配；JSE 到 JSONB 的直接转换、驱动连接与 HNSW SQL 是相对集中的工作。没有目标数据规模、并发指标和测试环境数据，不给出吞吐、延迟或开发天数承诺。
+
+最低验收集：
+
+- 不配置 storage 时，全套现有本地功能继续通过；未启用 PG feature 时不要求数据库服务。
+- 同一进程连接一个本地 shelf 和两个 PG schema，相同业务键不串数据。
+- CRUD、三元组及时间、JSON 类型边界、`$not-summaried`、含环 k-hop 使用共享用例验证。
+- 使用固定测试向量验证距离、维度和模型不匹配、空库、更新与删除；ANN 用召回指标及距离误差，不能要求近似结果集合始终完全相同。
+- 中文/英文全文检索对照召回与排序方向，排名差异明确记录。
+- 测试错误配置、缺环境变量、缺扩展、权限不足、连接超时、事务失败及并发更新时旧向量不得重新生效。
+- 检查内容导出导入、向量补全、附件引用、切换及包含切换后新数据的回退流程。
+- 对代表性数据执行查询计划与性能测量，再决定 HNSW 参数、索引组合及连接池规模。
+
+本次仅做代码审查和方案分析，未运行 PG 集成测试或性能测试。在线资料检索因当前搜索工具缺少 API key 未成功，因此不宣称已核实最新 pgvector 版本、依赖 feature 名称或维度限制；实施时固定 PostgreSQL/pgvector/驱动版本并实测。可查阅的官方资料入口为 [pgvector](https://github.com/pgvector/pgvector)、[pgvector-rust](https://github.com/pgvector/pgvector-rust)、[PostgreSQL JSON 类型](https://www.postgresql.org/docs/current/datatype-json.html) 与 [全文检索](https://www.postgresql.org/docs/current/textsearch.html)。
+
+## 11. 决策状态
+
+已确认：完整 PostgreSQL + pgvector 后端，并保留现有本地后端。
+
+本文建议作为实现起点的默认决策：每 shelf 配置、每 shelf 一个 PG schema、本地附件保留、同步驱动、可选编译 feature、配置切换不自动搬数据、保留 Parser/AST 并通过方言层直接生成 JSONB 查询、保留 JSE 现有候选筛选语义。它们足以形成可实施方案；若目标是大规模多租户托管、严格复刻 BM25 排名或跨机器自动共享附件，需要在实现前调整对应设计与验收范围。

--- a/docs/pgvector-backend.md
+++ b/docs/pgvector-backend.md
@@ -1,0 +1,164 @@
+# PostgreSQL + pgvector 后端
+
+Hypatia 可按 shelf 选择完整数据库后端。SQLite + FTS5 + usearch 仍为默认；`pgvector` 使用 PostgreSQL 管理 knowledge、statement、结构化查询、全文检索和向量。附件始终保存在 shelf 本地 `archives/` 目录。
+
+## 构建与测试
+
+```sh
+cargo build --release                         # 仅本地后端
+cargo build --release --features postgres-backend
+bash scripts/build.sh --features postgres-backend
+bash scripts/test-pgvector.sh
+```
+
+测试脚本要求本地已有 `pgvector/pgvector:pg17-trixie` 镜像，按镜像 ID 启动隔离容器和随机本机端口，安装扩展，执行默认与 PG 构建测试，退出时删除容器。它不使用机器上已有的 PostgreSQL 服务。实际验收镜像为 PostgreSQL 17.11 / pgvector 0.8.6；Rust 依赖固定在 Cargo.lock（postgres 0.19.14、pgvector 0.4.2、postgres-native-tls 0.5.3）。
+
+不带 feature 的二进制遇到 PG 配置会报“不支持，使用 --features postgres-backend 重建”，不会创建 SQLite 作为替代。交叉编译启用 PG 时，还需目标平台的 native-tls 系统依赖；本次不宣称已验证全部交叉编译目标。
+
+## Shelf 配置
+
+在连接之前创建目录和 `shelf.toml`：
+
+```toml
+[storage]
+backend = "pgvector"
+
+[storage.postgres]
+url_env = "HYPATIA_POSTGRES_URL"
+schema = "hypatia_team_memory"
+connect_timeout_seconds = 5
+statement_timeout_ms = 30000
+
+[storage.vector]
+index = "hnsw"
+metric = "cosine"
+
+[embedding]
+provider = "local"
+model = "BAAI/bge-m3"
+dimensions = 1024
+```
+
+数据库管理员预先执行 `CREATE EXTENSION vector`。应用账户需要连接数据库、创建自己的 schema 及其中对象的权限；已有 schema 需相应读写及初始化检查权限。一个 shelf 对应一个显式配置的 schema。schema 名称只接受 1–63 字节 ASCII 字母、数字、下划线，首字符不能是数字，禁止 public、information_schema 和 pg_*。同一数据库/schema 才共享数据，schema 名称本身不提供用户权限隔离。
+
+连接串有两种配置方式，`url_env` 和 `url` 必须且只能配置一个；两者同时出现、都未提供或值为空会报配置错误，不设置隐式优先级。原有 `url_env` 用法保持兼容。
+
+可以通过 `url_env` 指定环境变量，也可以把上例的 `[storage.postgres]` 替换为直接配置：
+
+```toml
+[storage.postgres]
+url = "postgresql://hypatia:your-password@db.example.com:5432/memory?sslmode=require"
+schema = "hypatia_team_memory"
+connect_timeout_seconds = 5
+statement_timeout_ms = 30000
+```
+
+配置后执行：
+
+```sh
+hypatia connect /path/to/team-shelf --name team
+hypatia knowledge-create "example" -d "正文" -s team
+hypatia search "正文" -s team
+hypatia backfill -s team
+```
+
+使用 `url` 时，连接串和密码保存在本地 shelf.toml；配置的 Debug 输出会隐藏 URL，连接解析错误不回显连接串，导出包不包含 shelf.toml 或连接凭据。远程 embedding 与数据库后端独立，仍支持已有的 `[embedding] provider="remote"`、`api_url`、`api_key_env`、`api_model`、`dimensions` 配置。
+
+没有 shelf.toml 或没有 storage 配置时选 SQLite；默认 shelf 读取 `~/.hypatia/default/shelf.toml`。已有文件无法读取、TOML 非法、未知配置字段/后端或缺少必要字段均报错。以前被忽略的非法旧配置会因此暴露。仅在连接时加载配置，修改后重新连接或重启。PG shelf 不创建 hypatia.sqlite 或 vectors/，连接失败不会切换到本地。非默认 shelf 恢复失败会显示警告并保持未连接，操作该 shelf 会明确失败；默认 shelf 失败使启动失败。
+
+## TLS 与模型身份
+
+生产连接建议显式 `sslmode=require`。本实现的同步 postgres 驱动结合 native-tls：require 要求 TLS，并通过系统信任根校验证书链及主机名；默认 prefer 在服务端不支持 TLS 时允许明文，不应作为必须加密的部署配置。驱动不接受 libpq 的 verify-ca、verify-full 拼写或 sslrootcert 参数，这些配置会报错，不会被静默忽略。私有 CA 应通过操作系统信任配置管理。TLS 行为按驱动实现说明，本次 Docker 测试使用 sslmode=disable，没有运行证书轮换/私有 CA 部署测试。
+
+PG 连接必须能识别向量模型：本地配置显式 model，或可读取本地模型和 tokenizer 的内容指纹；模型文件暂时不存在时，配置 model 仍可使普通 CRUD 工作。远程身份包含模型名和 endpoint 的哈希，不泄露连接凭据。本地未命名模型使用模型/tokenizer 内容指纹；命名模型按声明的模型标识、tokenizer 配置、pooling 和 max_seq_length 识别。操作者必须为不同模型版本使用不同 model 标识；不要用同一标识替换成不同模型。
+
+模型、维度、距离或 PG 索引模式与已有 metadata 不一致时拒绝连接。改变模型/维度应逻辑导出后，以 --reembed 导入新配置的空 shelf/schema，再 backfill；修改 TOML 不是模型迁移。
+
+向量只接受正确维度、有限值和非零范数。cosine 距离越小越相似。HNSW 的 vector 类型最多支持 2000 维；需要更高维度时必须显式设置 index="none"，使用精确扫描（存储上限 16000 维）。不自动采用 halfvec 或降维。
+
+## 查询语义与已确认差异
+
+- Parser/AST 保持不变，PG 方言直接生成参数化 SQL，schema、业务表和扩展对象均明确限定；不替换已有 SQLite SQL 中的问号。
+- `$search` / `$similar` 仍先选候选键，再执行普通条件查询并按创建时间排序；不保证最终保持相关度/距离顺序，也不下推普通条件后重新选择 top-k。分页沿用现有 JSE 行为。
+- PG 使用 simple 文本配置、现有 Jieba 预分词和 key/data/tags/synonyms 的相对权重 10/1/5/3。空格表示 AND，支持显式 AND/OR；PG ts_rank 返回负值以保持“越小越优”。PG 不复刻 Porter 词干或 FTS5 BM25，召回、排序和分数可不同。用户已接受这一差异。
+- **用户已选择保留 SQLite 旧行为**：PG 的 data.foo / data[index] 比较使用受控解析后的 payload；非法内层 JSON 得到 NULL。SQLite 普通比较仍对 Content.data 字符串执行原 JSON1 路径访问，data.foo 可能匹配不到。SQLite 已有 `$has` 的 data.foo token 查询保持原样。
+- `$has` 使用字面字段名，例如 `["$has","tags","rust"]`，不是 `$tags`。PG 写事务维护派生 tokens JSONB，使字符串/数字/布尔/null 和旧索引递归预算的 membership 语义一致，包括科学计数法 token。它是行内派生数据，不是复制一张 SQLite json_index 表。
+- `$json-contains` 使用原生 JSONB 包含预筛选加严格递归复核，避免把 PG 数组包含标量的额外规则带入原契约。数值比较对非法文本受控转换，不因一条无效内容让整批查询失败。
+- PG k-hop 去重有环图的边/深度状态，最大深度 100，并受 statement_timeout 限制。
+- CRUD/JSE Content 保持对象；全文检索 content 保持 JSON 字符串；语义检索 content 现在统一为 JSON 对象，消除本地 ANN 与旧暴力 fallback 的不一致。时间仍为 UTC 约定下的 timestamp without time zone / NaiveDateTime。PG 仅接受微秒精度及普通时间，拒绝会丢失纳秒或闰秒编码的写入/导入，而不静默截断；total_count 仍是返回行数。
+
+## 正文提交与 backfill
+
+正文、FTS 和 JSON 派生数据在事务内提交。更新正文同时使旧向量失效。模型推理在事务外执行，生成后按内容版本条件写回；更新或删除再创建产生新版本，旧工作不能覆盖新正文。
+
+正文保存成功但模型不可用、推理失败或向量写回失败时，CRUD 仍返回已保存的记录，同时在 stderr 提示“content saved; embedding pending”及 backfill。不要把这种状态当作正文创建失败而重复创建。
+
+`hypatia backfill -s team` 分页补缺失向量，可重复执行。失败的条目在下次运行重试；并发改变的条目拒绝安装旧向量。PG 索引由数据库维护，backfill 不保存或重建 usearch 文件。
+
+旧 SQLite 向量没有可信模型元数据时，不推断其模型，也不与新模型混用。普通 CRUD 和逻辑导出仍可用，语义检索/向量安装提示需要显式重建。模型可用后运行：
+
+```sh
+hypatia backfill -s old-local --reembed
+```
+
+此选项先显式清空派生向量并使在途任务的版本失效，再用已配置模型重新生成；正文不变。失败后可用普通 backfill 续补。已知模型身份改变仍建议使用新的空 shelf/schema，保留切换备份。
+
+## 导出、迁移与回退
+
+`hypatia export <shelf> <empty-directory>` 生成：
+
+- manifest.json：格式版本、行数和 snapshot/附件 SHA-256 清单；
+- snapshot.json：knowledge/statement、完整 Content、时间、有效向量及模型元数据；
+- archives/：本地附件；
+- 本地源额外保留 hypatia.sqlite，兼容旧目录导出格式。SQLite 使用 backup API，逻辑快照来自同一备份；PG 使用 repeatable-read 一致性只读事务。
+
+输出先写临时目录，完成校验后一次 rename 发布。导出目标必须为空且在源 shelf 之外。数据库快照不等于附件文件系统快照；导出期间请暂停附件修改。导出不携带 shelf.toml、连接串、密码或本地模型文件，目标连接和 embedding 配置由操作者提供。
+
+迁移示例：
+
+```sh
+# 1. 源继续保留，先导出备份
+hypatia export old-local /backups/to-pg
+
+# 2. 创建 target 目录及本文 PG shelf.toml，使用独立空 schema
+hypatia connect /path/to/pg-target --name pg-target
+
+# 3. 已有可信同模型向量可直接保留
+hypatia import /backups/to-pg -s pg-target
+
+# 或明确丢弃向量，按目标模型补齐
+hypatia import /backups/to-pg -s pg-target --reembed
+hypatia backfill -s pg-target
+```
+
+上面两条 import 是二选一，目标必须为空，重复键不隐式覆盖。导入先验证清单、行数和附件引用，再事务写入数据，随后按规范化内容、主键、时间与向量逐记录验证。源导出无可信向量身份时自动省略向量并在 backfill 重建。旧的仅 hypatia.sqlite + archives/ 导出可导入，源数据库只读备份到临时目录后再读取，不原地迁移源备份。
+
+当前逻辑包在进程内加载后用一个事务导入；失败回滚可从完整包重试，未提供超大包的跨事务断点续传。附件先复制到目标，冲突内容拒绝覆盖；若后续数据库事务失败，已复制的相同附件可保留并用于重试。数据库数据提交成功后维护/验证失败会明确报告，保留源包供检查。
+
+验证通过后再修改原目录配置或让调用方使用新 shelf 名称。修改 backend 只切换目标，不搬运数据。要保留切换后在 PG 新增的数据进行回退，应从 PG 再 export，import 到新的空 SQLite shelf，再切换调用方。单纯改回 backend="sqlite" 只能看到原本地旧数据。
+
+多客户端共享 PG 不会自动共享本地附件。跨机器时需自行共享 archives 目录，或分别部署随导出包复制的附件。
+
+## 库 API 与内部生命周期
+
+OpenShelf.store 和公开 vectors 已替换为 OpenShelf.backend、settings。ShelfBackend 将 LocalBackend 的 SqliteStore/usearch 文件封装在内部；调用方不能再通过 OpenShelf.store.conn() 访问 SQLite。SqliteStore 的 insert/update 返回内容版本 i64，原只忽略返回值的调用不受影响。直接依赖这些公开字段/精确函数签名的 Rust 用户需要适配；这属于库 API 变更。
+
+本地 schema 升至版本 3，新增内容版本时钟和缓存失效触发器，打开拒绝未知未来版本。usearch 是可重建缓存，跨连接读操作用同一 SQLite 快照校验时钟并读取正文；缓存文件采用独立临时文件和版本清单，失效后刷新，缓存持久化失败可继续精确检索。PG 提交不依赖 Drop，也不自动重试提交状态未知的写操作。
+
+性能验收使用确定性向量和真实查询计划。1024 维样例验证 HNSW 索引可用与 index=none 精确扫描；小样本强制禁用顺序扫描只证明访问路径可用，不构成实际延迟或吞吐承诺。应按实际数据规模重新测量，再调整连接池、HNSW 参数和索引组合。
+
+## 本次验证记录
+
+| 验证 | 结果 |
+| --- | --- |
+| 默认构建单元测试 | 170 通过 |
+| 默认共享后端/迁移契约 | 5 通过 |
+| PG feature 单元测试（含真实 SQL 对照） | 172 通过 |
+| PG feature 共享后端及迁移往返 | 6 通过 |
+| PG 连接脱敏及真实故障、并发与访问路径测试 | 8 通过 |
+| 默认与 PG feature 的 locked release 构建 | 均通过 |
+| 独立 Docker 验收脚本 | 通过，容器自动清理 |
+| 默认依赖检查 | 无 PostgreSQL 特有依赖 |
+| 仓库小型基准 | 通过 |
+
+完整 cargo test 还会启动已有 LoCoMo 模型评测，本次在 300 秒限制后超时，未宣称完成该评测或后续 LongMemEval。常规验收使用上面的确定性测试；TLS 私有 CA 部署和所有交叉编译平台也未在本次实测。

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,7 @@
 #   ./scripts/build.sh --backend cross <target> # use cross instead of zigbuild
 #   ./scripts/build.sh --debug <target>         # debug build
 #   ./scripts/build.sh --no-strip <target>      # skip strip step
+#   ./scripts/build.sh --features postgres-backend # include PostgreSQL support
 #
 # Prerequisites:
 #   - rustup + cargo
@@ -75,8 +76,13 @@ NATIVE_TARGET="$(rustc -vV | sed -n 's/^host: //p')"
 # ─── Arg parsing ───
 
 TARGETS=()
+FEATURE_FLAGS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --features)
+            FEATURE_FLAGS=(--features "${2:?--features requires a value}")
+            shift 2
+            ;;
         --backend)
             BACKEND="$2"
             shift 2
@@ -149,7 +155,7 @@ build_native() {
         profile_flag=(--release)
     fi
 
-    cargo build --target "$target" "${profile_flag[@]}" -p hypatia
+    cargo build --target "$target" "${profile_flag[@]}" ${FEATURE_FLAGS[@]+"${FEATURE_FLAGS[@]}"} -p hypatia
 
     post_build "$target"
 }
@@ -166,7 +172,7 @@ build_zigbuild() {
         profile_flag=(--release)
     fi
 
-    cargo zigbuild --target "$target" "${profile_flag[@]}" -p hypatia
+    cargo zigbuild --target "$target" "${profile_flag[@]}" ${FEATURE_FLAGS[@]+"${FEATURE_FLAGS[@]}"} -p hypatia
 
     post_build "$target"
 }
@@ -183,7 +189,7 @@ build_cross() {
         profile_flag=(--release)
     fi
 
-    cross build --target "$target" "${profile_flag[@]}" -p hypatia
+    cross build --target "$target" "${profile_flag[@]}" ${FEATURE_FLAGS[@]+"${FEATURE_FLAGS[@]}"} -p hypatia
 
     post_build "$target"
 }

--- a/scripts/test-pgvector.sh
+++ b/scripts/test-pgvector.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Uses a disposable container; never targets an existing PostgreSQL installation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+image="${HYPATIA_PGVECTOR_TEST_IMAGE:-pgvector/pgvector:pg17-trixie}"
+container="hypatia-pgvector-test-$$"
+cleanup() { docker rm -f "$container" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+image_id="$(docker image inspect "$image" --format '{{.Id}}')"
+printf 'Testing image %s (%s)\n' "$image" "$image_id"
+docker run -d --name "$container" -e POSTGRES_PASSWORD=hypatia-test-only -e POSTGRES_DB=hypatia_test -p 127.0.0.1:0:5432 "$image_id" >/dev/null
+ready=false
+for attempt in $(seq 1 30); do
+    if docker exec "$container" pg_isready -h 127.0.0.1 -U postgres -d hypatia_test >/dev/null 2>&1; then ready=true; break; fi
+    sleep 1
+done
+if [ "$ready" != true ]; then docker logs "$container"; exit 1; fi
+port="$(docker port "$container" 5432/tcp | awk -F: '{print $NF}')"
+docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d hypatia_test -c "CREATE EXTENSION vector; SELECT version(); SELECT extversion FROM pg_extension WHERE extname = 'vector';"
+export HYPATIA_TEST_POSTGRES_URL="postgres://postgres:hypatia-test-only@127.0.0.1:$port/hypatia_test?sslmode=disable"
+cargo test --locked --lib --test backend_contract
+cargo test --locked --features postgres-backend --lib --test backend_contract --test postgres_store -- --include-ignored

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -23,9 +23,7 @@ enum Commands {
         name: Option<String>,
     },
     /// Disconnect from a shelf
-    Disconnect {
-        name: String,
-    },
+    Disconnect { name: String },
     /// List connected shelves
     List,
     /// Execute a JSE query
@@ -122,12 +120,21 @@ enum Commands {
         shelf: String,
     },
     /// Export a shelf to another directory
-    Export {
-        name: String,
-        dest: PathBuf,
+    Export { name: String, dest: PathBuf },
+    /// Import an export into an empty configured shelf (does not switch backends)
+    Import {
+        source: PathBuf,
+        #[arg(short, long, default_value = "default")]
+        shelf: String,
+        /// Omit exported vectors; use backfill with the target model afterwards
+        #[arg(long)]
+        reembed: bool,
     },
     /// Generate embeddings for existing entries that don't have vectors yet
     Backfill {
+        /// Explicitly invalidate all vectors and regenerate with the configured model
+        #[arg(long)]
+        reembed: bool,
         /// Shelf to backfill
         #[arg(short, long, default_value = "default")]
         shelf: String,
@@ -225,8 +232,18 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
                 // Calculate column widths for alignment
                 let max_name = shelves.iter().map(|(n, _, _)| n.len()).max().unwrap_or(0);
                 for (name, path, connected) in &shelves {
-                    let status = if *connected { "[connected]" } else { "[disconnected]" };
-                    println!("  {:width$}  {}  {}", name, path.display(), status, width = max_name);
+                    let status = if *connected {
+                        "[connected]"
+                    } else {
+                        "[disconnected]"
+                    };
+                    println!(
+                        "  {:width$}  {}  {}",
+                        name,
+                        path.display(),
+                        status,
+                        width = max_name
+                    );
                 }
             }
         }
@@ -236,7 +253,15 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
             let result = lab.query(&shelf, &json)?;
             print_result(&result);
         }
-        Commands::KnowledgeCreate { name, data, tags, synonyms, figures, scopes, shelf } => {
+        Commands::KnowledgeCreate {
+            name,
+            data,
+            tags,
+            synonyms,
+            figures,
+            scopes,
+            shelf,
+        } => {
             let tags_vec: Vec<String> = if tags.is_empty() {
                 Vec::new()
             } else {
@@ -245,21 +270,34 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
             let syn = if synonyms.is_empty() {
                 None
             } else {
-                let list: Vec<String> = synonyms.split(',')
+                let list: Vec<String> = synonyms
+                    .split(',')
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
                     .collect();
-                if list.is_empty() { None } else { Some(Synonyms::Flat(list)) }
+                if list.is_empty() {
+                    None
+                } else {
+                    Some(Synonyms::Flat(list))
+                }
             };
             let figures_vec: Vec<String> = if figures.is_empty() {
                 Vec::new()
             } else {
-                figures.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect()
+                figures
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
             };
             let scopes_vec: Vec<String> = if scopes.is_empty() {
                 Vec::new()
             } else {
-                scopes.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect()
+                scopes
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
             };
             // Treat trailing comma as implicit global scope
             let scopes_vec = if scopes.ends_with(',') && !scopes_vec.contains(&String::new()) {
@@ -277,37 +315,47 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
             let k = lab.create_knowledge(&shelf, &name, content)?;
             println!("Created knowledge: {}", k.name);
         }
-        Commands::KnowledgeGet { name, shelf } => {
-            match lab.get_knowledge(&shelf, &name)? {
-                Some(k) => {
-                    let json = serde_json::to_string_pretty(&serde_json::json!({
-                        "name": k.name,
-                        "content": k.content,
-                        "created_at": k.created_at.to_string(),
-                    }))?;
-                    println!("{json}");
-                }
-                None => println!("Knowledge '{}' not found.", name),
+        Commands::KnowledgeGet { name, shelf } => match lab.get_knowledge(&shelf, &name)? {
+            Some(k) => {
+                let json = serde_json::to_string_pretty(&serde_json::json!({
+                    "name": k.name,
+                    "content": k.content,
+                    "created_at": k.created_at.to_string(),
+                }))?;
+                println!("{json}");
             }
-        }
+            None => println!("Knowledge '{}' not found.", name),
+        },
         Commands::KnowledgeDelete { name, shelf } => {
             lab.delete_knowledge(&shelf, &name)?;
             println!("Deleted knowledge: {name}");
         }
-        Commands::StatementDelete { head, relation, tail, shelf } => {
+        Commands::StatementDelete {
+            head,
+            relation,
+            tail,
+            shelf,
+        } => {
             let key = StatementKey::new(&head, &relation, &tail);
             lab.delete_statement(&shelf, &key)?;
             println!("Deleted statement: ({}, {}, {})", head, relation, tail);
         }
-        Commands::StatementCreate { head, relation, tail, data, synonyms, scopes, shelf } => {
+        Commands::StatementCreate {
+            head,
+            relation,
+            tail,
+            data,
+            synonyms,
+            scopes,
+            shelf,
+        } => {
             let key = StatementKey::new(&head, &relation, &tail);
             let syn = match synonyms {
                 Some(ref json_str) => {
                     let map: std::collections::HashMap<String, Vec<String>> =
-                        serde_json::from_str(json_str)
-                        .map_err(|e| crate::error::HypatiaError::Parse(
-                            format!("invalid synonyms JSON: {e}")
-                        ))?;
+                        serde_json::from_str(json_str).map_err(|e| {
+                            crate::error::HypatiaError::Parse(format!("invalid synonyms JSON: {e}"))
+                        })?;
                     Some(Synonyms::Positional(map))
                 }
                 None => None,
@@ -315,7 +363,11 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
             let scopes_vec: Vec<String> = if scopes.is_empty() {
                 Vec::new()
             } else {
-                scopes.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect()
+                scopes
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
             };
             let scopes_vec = if scopes.ends_with(',') && !scopes_vec.contains(&String::new()) {
                 let mut v = scopes_vec;
@@ -324,11 +376,22 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
             } else {
                 scopes_vec
             };
-            let content = Content::new(&data).with_synonyms(syn).with_scopes(scopes_vec);
+            let content = Content::new(&data)
+                .with_synonyms(syn)
+                .with_scopes(scopes_vec);
             let s = lab.create_statement(&shelf, &key, content, None, None)?;
-            println!("Created statement: ({}, {}, {})", s.key.head, s.key.relation, s.key.tail);
+            println!(
+                "Created statement: ({}, {}, {})",
+                s.key.head, s.key.relation, s.key.tail
+            );
         }
-        Commands::Search { query, catalog, limit, offset, shelf } => {
+        Commands::Search {
+            query,
+            catalog,
+            limit,
+            offset,
+            shelf,
+        } => {
             let opts = SearchOpts {
                 catalog,
                 limit,
@@ -337,7 +400,12 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
             let result = lab.search(&shelf, &query, opts)?;
             print_result(&result);
         }
-        Commands::Similar { query, target, limit, shelf } => {
+        Commands::Similar {
+            query,
+            target,
+            limit,
+            shelf,
+        } => {
             let result = lab.similar(&shelf, &query, &target, limit)?;
             print_result(&result);
         }
@@ -345,13 +413,27 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
             lab.export_shelf(&name, &dest)?;
             println!("Exported shelf '{name}' to {}", dest.display());
         }
-        Commands::Backfill { shelf } => {
-            let stats = lab.backfill_vectors(&shelf)?;
-            println!("Backfill complete: {} vectors created, {} skipped, {} errors",
-                stats.created, stats.skipped, stats.errors);
+        Commands::Import {
+            source,
+            shelf,
+            reembed,
+        } => {
+            lab.import_shelf(&shelf, &source, reembed)?;
+            println!(
+                "Imported {} into shelf '{shelf}'; connection configuration unchanged",
+                source.display()
+            );
+        }
+        Commands::Backfill { shelf, reembed } => {
+            let stats = lab.backfill_vectors_with_reembed(&shelf, reembed)?;
+            println!(
+                "Backfill complete: {} vectors created, {} skipped, {} errors",
+                stats.created, stats.skipped, stats.errors
+            );
         }
         Commands::ArchiveStore { file, name, shelf } => {
-            let file_name = file.file_name()
+            let file_name = file
+                .file_name()
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_else(|| "unnamed".to_string());
             let dest_relative = name.unwrap_or(file_name);
@@ -394,7 +476,8 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
                 "filename": dest_relative,
                 "size_bytes": size_bytes,
                 "mime_type": mime_type
-            }).to_string();
+            })
+            .to_string();
 
             let content = Content::new(&meta_data)
                 .with_format(crate::model::Format::Json)
@@ -409,30 +492,29 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
 
             // Create statement: <name> is_a archive
             let key = StatementKey::new(&dest_relative, "is_a", "archive");
-            let stmt_content = Content::new("")
-                .with_tags(vec!["archive".to_string()]);
+            let stmt_content = Content::new("").with_tags(vec!["archive".to_string()]);
             let _ = lab.create_statement(&shelf, &key, stmt_content, None, None);
 
             println!("Stored: archive://{}", dest_relative);
             println!("Knowledge: {}", k.name);
             println!("MIME: {}, Size: {} bytes", mime_type, size_bytes);
         }
-        Commands::ArchiveGet { name, output, shelf } => {
-            match lab.get_archive_path(&shelf, &name) {
-                Some(path) => {
-                    match output {
-                        Some(dest) => {
-                            std::fs::copy(&path, &dest)?;
-                            println!("Copied to: {}", dest.display());
-                        }
-                        None => {
-                            println!("{}", path.display());
-                        }
-                    }
+        Commands::ArchiveGet {
+            name,
+            output,
+            shelf,
+        } => match lab.get_archive_path(&shelf, &name) {
+            Some(path) => match output {
+                Some(dest) => {
+                    std::fs::copy(&path, &dest)?;
+                    println!("Copied to: {}", dest.display());
                 }
-                None => println!("Archive '{}' not found in shelf '{}'.", name, shelf),
-            }
-        }
+                None => {
+                    println!("{}", path.display());
+                }
+            },
+            None => println!("Archive '{}' not found in shelf '{}'.", name, shelf),
+        },
         Commands::ArchiveList { shelf } => {
             let files = lab.list_archives(&shelf)?;
             if files.is_empty() {
@@ -445,17 +527,21 @@ fn execute_command(lab: &mut Lab, cmd: Commands) -> crate::error::Result<()> {
             }
         }
         Commands::SessionCurrent { scope, shelf } => {
-            let mut conditions = vec![
-                serde_json::json!(["$contains", "scopes", scope.as_deref().unwrap_or("")]),
-            ];
+            let mut conditions = vec![serde_json::json!([
+                "$contains",
+                "scopes",
+                scope.as_deref().unwrap_or("")
+            ])];
             if let Some(ref s) = scope {
                 if !s.is_empty() {
-                    conditions = vec![
-                        serde_json::json!(["$contains", "scopes", s]),
-                    ];
+                    conditions = vec![serde_json::json!(["$contains", "scopes", s])];
                 }
             }
-            let jse = serde_json::json!(["$not-summaried", "message", conditions.into_iter().next().unwrap()]);
+            let jse = serde_json::json!([
+                "$not-summaried",
+                "message",
+                conditions.into_iter().next().unwrap()
+            ]);
             let result = lab.query(&shelf, &jse)?;
             if result.rows.is_empty() {
                 println!("No unsummarized messages.");
@@ -484,8 +570,7 @@ fn execute_model_command(cmd: ModelCommands) -> crate::error::Result<()> {
             } else {
                 for (name, path) in &models {
                     // Show symlink target if applicable
-                    let resolved = std::fs::canonicalize(path)
-                        .unwrap_or_else(|_| path.clone());
+                    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
                     if resolved != *path {
                         println!("  {} -> {}", name, resolved.display());
                     } else {
@@ -504,45 +589,45 @@ fn execute_model_command(cmd: ModelCommands) -> crate::error::Result<()> {
                 }
                 Err(e) => {
                     return Err(crate::error::HypatiaError::Config(format!(
-                        "failed to register model '{}': {}", name, e
+                        "failed to register model '{}': {}",
+                        name, e
                     )));
                 }
             }
         }
-        ModelCommands::Show { name } => {
-            match crate::embedding::config::model_info(&name) {
-                Ok(info) => {
-                    println!("Model: {}", info.name);
-                    println!("Directory: {}", info.directory.display());
-                    println!("ONNX: {}", info.model_path.display());
-                    println!("Tokenizer: {}", info.tokenizer_path.display());
-                    println!("Files:");
-                    for f in &info.files {
-                        let size = if f.size_bytes >= 1_073_741_824 {
-                            format!("{:.1} GB", f.size_bytes as f64 / 1_073_741_824.0)
-                        } else if f.size_bytes >= 1_048_576 {
-                            format!("{:.1} MB", f.size_bytes as f64 / 1_048_576.0)
-                        } else if f.size_bytes >= 1024 {
-                            format!("{:.1} KB", f.size_bytes as f64 / 1024.0)
-                        } else {
-                            format!("{} B", f.size_bytes)
-                        };
-                        println!("  {:30} {}", f.name, size);
-                    }
-                    let total = if info.total_size_bytes >= 1_073_741_824 {
-                        format!("{:.1} GB", info.total_size_bytes as f64 / 1_073_741_824.0)
+        ModelCommands::Show { name } => match crate::embedding::config::model_info(&name) {
+            Ok(info) => {
+                println!("Model: {}", info.name);
+                println!("Directory: {}", info.directory.display());
+                println!("ONNX: {}", info.model_path.display());
+                println!("Tokenizer: {}", info.tokenizer_path.display());
+                println!("Files:");
+                for f in &info.files {
+                    let size = if f.size_bytes >= 1_073_741_824 {
+                        format!("{:.1} GB", f.size_bytes as f64 / 1_073_741_824.0)
+                    } else if f.size_bytes >= 1_048_576 {
+                        format!("{:.1} MB", f.size_bytes as f64 / 1_048_576.0)
+                    } else if f.size_bytes >= 1024 {
+                        format!("{:.1} KB", f.size_bytes as f64 / 1024.0)
                     } else {
-                        format!("{:.1} MB", info.total_size_bytes as f64 / 1_048_576.0)
+                        format!("{} B", f.size_bytes)
                     };
-                    println!("Total: {}", total);
+                    println!("  {:30} {}", f.name, size);
                 }
-                Err(e) => {
-                    return Err(crate::error::HypatiaError::Config(format!(
-                        "model '{}' not found: {}", name, e
-                    )));
-                }
+                let total = if info.total_size_bytes >= 1_073_741_824 {
+                    format!("{:.1} GB", info.total_size_bytes as f64 / 1_073_741_824.0)
+                } else {
+                    format!("{:.1} MB", info.total_size_bytes as f64 / 1_048_576.0)
+                };
+                println!("Total: {}", total);
             }
-        }
+            Err(e) => {
+                return Err(crate::error::HypatiaError::Config(format!(
+                    "model '{}' not found: {}",
+                    name, e
+                )));
+            }
+        },
     }
     Ok(())
 }

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -14,7 +14,10 @@ impl Repl {
     }
 
     pub fn run(&mut self) -> Result<()> {
-        println!("hypatia {} — AI-oriented memory management", env!("CARGO_PKG_VERSION"));
+        println!(
+            "hypatia {} — AI-oriented memory management",
+            env!("CARGO_PKG_VERSION")
+        );
         println!("Type .help for commands, or enter JSE queries as JSON.");
 
         loop {
@@ -74,13 +77,14 @@ impl Repl {
             }
             "connect" => {
                 let path = parts.get(1).ok_or_else(|| {
-                    crate::error::HypatiaError::Validation("usage: .connect <path> [name]".to_string())
+                    crate::error::HypatiaError::Validation(
+                        "usage: .connect <path> [name]".to_string(),
+                    )
                 })?;
                 let name = parts.get(2).map(|s| s.to_string());
-                let shelf_name = self.lab.connect_shelf(
-                    std::path::Path::new(path),
-                    name.as_deref(),
-                )?;
+                let shelf_name = self
+                    .lab
+                    .connect_shelf(std::path::Path::new(path), name.as_deref())?;
                 println!("Connected to shelf: {shelf_name}");
             }
             "disconnect" => {
@@ -97,17 +101,31 @@ impl Repl {
                 } else {
                     let max_name = shelves.iter().map(|(n, _, _)| n.len()).max().unwrap_or(0);
                     for (name, path, connected) in &shelves {
-                        let status = if *connected { "[connected]" } else { "[disconnected]" };
-                        println!("  {:width$}  {}  {}", name, path.display(), status, width = max_name);
+                        let status = if *connected {
+                            "[connected]"
+                        } else {
+                            "[disconnected]"
+                        };
+                        println!(
+                            "  {:width$}  {}  {}",
+                            name,
+                            path.display(),
+                            status,
+                            width = max_name
+                        );
                     }
                 }
             }
             "export" => {
                 let name = parts.get(1).ok_or_else(|| {
-                    crate::error::HypatiaError::Validation("usage: .export <name> <dest>".to_string())
+                    crate::error::HypatiaError::Validation(
+                        "usage: .export <name> <dest>".to_string(),
+                    )
                 })?;
                 let dest = parts.get(2).ok_or_else(|| {
-                    crate::error::HypatiaError::Validation("usage: .export <name> <dest>".to_string())
+                    crate::error::HypatiaError::Validation(
+                        "usage: .export <name> <dest>".to_string(),
+                    )
                 })?;
                 self.lab.export_shelf(name, std::path::Path::new(dest))?;
                 println!("Exported shelf '{name}' to {dest}");

--- a/src/embedding/config.rs
+++ b/src/embedding/config.rs
@@ -3,6 +3,10 @@ use std::path::{Path, PathBuf};
 /// Embedding configuration loaded from `shelf.toml` (or defaults).
 #[derive(Debug, Clone)]
 pub struct EmbeddingConfig {
+    /// Stable configured model identity, independent of the local model cache.
+    pub model_identity: String,
+    /// True when a configured model name or local artifact fingerprint is available.
+    pub model_identity_trusted: bool,
     /// Which provider to use: "local" (ONNX) or "remote" (HTTP API).
     pub provider: ProviderKind,
     /// Local ONNX settings.
@@ -56,9 +60,9 @@ struct ShelfToml {
 
 /// Parsed `[embedding]` section from `shelf.toml`.
 #[derive(Debug, Clone, serde::Deserialize)]
-#[serde(default)]
-struct EmbeddingToml {
-    provider: String,
+#[serde(default, deny_unknown_fields)]
+pub(crate) struct EmbeddingToml {
+    pub(crate) provider: String,
     /// HuggingFace-style model reference (e.g. "BAAI/bge-m3") or absolute path.
     model: Option<String>,
     /// Explicit model file path (backward compat).
@@ -114,10 +118,7 @@ pub fn resolve_model(model_ref: &str) -> Result<ResolvedModel, String> {
     }
 
     // Case 2: ~/.hypatia/models/<org>/<name>/
-    let hypatia_model_dir = dirs_home()
-        .join(".hypatia")
-        .join("models")
-        .join(model_ref);
+    let hypatia_model_dir = dirs_home().join(".hypatia").join("models").join(model_ref);
     if hypatia_model_dir.is_dir() {
         return resolve_model_dir(&hypatia_model_dir, model_ref);
     }
@@ -159,12 +160,8 @@ fn resolve_model_dir(dir: &Path, _model_ref: &str) -> Result<ResolvedModel, Stri
         )
     })?;
 
-    let tokenizer_path = find_tokenizer_file(dir).ok_or_else(|| {
-        format!(
-            "no tokenizer.json found in {}",
-            dir.display()
-        )
-    })?;
+    let tokenizer_path = find_tokenizer_file(dir)
+        .ok_or_else(|| format!("no tokenizer.json found in {}", dir.display()))?;
 
     Ok(ResolvedModel {
         model_dir: dir.to_path_buf(),
@@ -315,10 +312,7 @@ pub fn list_local_models() -> Vec<(String, PathBuf)> {
                     };
                     // Check it looks like a model dir (has at least one .onnx or tokenizer.json)
                     if is_model_dir(&model_entry.path()) {
-                        results.push((
-                            format!("{}/{}", org_name, model_name),
-                            model_entry.path(),
-                        ));
+                        results.push((format!("{}/{}", org_name, model_name), model_entry.path()));
                     }
                 }
             }
@@ -334,7 +328,11 @@ pub fn list_local_models() -> Vec<(String, PathBuf)> {
             }
             if let Some(name) = entry.file_name().to_str() {
                 // Skip if already listed as part of an org/name pair
-                if !name.contains('/') && !results.iter().any(|(n, _)| n.starts_with(&format!("{}/", name))) {
+                if !name.contains('/')
+                    && !results
+                        .iter()
+                        .any(|(n, _)| n.starts_with(&format!("{}/", name)))
+                {
                     if is_model_dir(&path) && find_tokenizer_file(&path).is_none() {
                         // This is an org dir, not a flat model
                     } else if is_model_dir(&path) && find_tokenizer_file(&path).is_some() {
@@ -364,7 +362,10 @@ pub fn register_model(name: &str, source_path: &Path) -> Result<PathBuf, String>
     let target = dirs_home().join(".hypatia").join("models").join(name);
 
     if !source_path.is_dir() {
-        return Err(format!("source path is not a directory: {}", source_path.display()));
+        return Err(format!(
+            "source path is not a directory: {}",
+            source_path.display()
+        ));
     }
 
     if !is_model_dir(source_path) {
@@ -420,7 +421,10 @@ pub fn model_info(name: &str) -> Result<ModelInfo, String> {
                     .to_string();
                 let size = meta.len();
                 total_size += size;
-                files.push(ModelFile { name: file_name, size_bytes: size });
+                files.push(ModelFile {
+                    name: file_name,
+                    size_bytes: size,
+                });
             }
         }
     }
@@ -480,6 +484,38 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn identity_hash(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+fn artifact_identity(model: &Path, tokenizer: &Path) -> Option<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    let mut hash = Sha256::new();
+    for path in [model, tokenizer] {
+        let mut file = std::fs::File::open(path).ok()?;
+        hash.update(file.metadata().ok()?.len().to_le_bytes());
+        let mut buffer = [0u8; 65536];
+        loop {
+            let n = file.read(&mut buffer).ok()?;
+            if n == 0 {
+                break;
+            }
+            hash.update(&buffer[..n]);
+        }
+    }
+    Some(format!(
+        "artifacts:{}",
+        hash.finalize()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>()
+    ))
+}
+
 // ── EmbeddingConfig construction ──────────────────────────────────────
 
 impl EmbeddingConfig {
@@ -496,6 +532,12 @@ impl EmbeddingConfig {
             EmbeddingToml::default()
         };
 
+        Self::from_parsed(toml, shelf_dir)
+    }
+
+    pub(crate) fn from_parsed(toml: EmbeddingToml, shelf_dir: &Path) -> Self {
+        let configured_model = toml.model.clone();
+        let configured_tokenizer = toml.tokenizer_path.clone();
         let provider = match toml.provider.as_str() {
             "remote" => ProviderKind::Remote,
             _ => ProviderKind::Local,
@@ -510,9 +552,17 @@ impl EmbeddingConfig {
             match resolve_model(model_ref) {
                 Ok(resolved) => (resolved.model_path, resolved.tokenizer_path),
                 Err(e) => {
-                    eprintln!("warning: model resolution failed for '{}': {}", model_ref, e);
-                    // Fall through to model_path or defaults
-                    resolve_legacy_paths(&toml, shelf_dir)
+                    eprintln!(
+                        "warning: model resolution failed for '{}': {}",
+                        model_ref, e
+                    );
+                    // An explicitly selected model must never run a different shelf-local model.
+                    // Keep unavailable paths for the selected identity; normal CRUD still works.
+                    let unavailable = dirs_home().join(".hypatia").join("models").join(model_ref);
+                    (
+                        unavailable.join("embedding_model.onnx"),
+                        unavailable.join("tokenizer.json"),
+                    )
                 }
             }
         } else {
@@ -531,20 +581,56 @@ impl EmbeddingConfig {
             api_url: toml
                 .api_url
                 .unwrap_or_else(|| "https://api.openai.com/v1/embeddings".into()),
-            api_key_env: toml
-                .api_key_env
-                .unwrap_or_else(|| "OPENAI_API_KEY".into()),
+            api_key_env: toml.api_key_env.unwrap_or_else(|| "OPENAI_API_KEY".into()),
             api_model: toml
                 .api_model
                 .unwrap_or_else(|| "text-embedding-3-small".into()),
             dimensions,
         };
 
+        let (model_identity, model_identity_trusted) = match provider {
+            ProviderKind::Remote => (
+                format!(
+                    "remote:{}:endpoint:{}",
+                    remote.api_model,
+                    identity_hash(remote.api_url.as_bytes())
+                ),
+                true,
+            ),
+            ProviderKind::Local => {
+                let identity = if let Some(name) = configured_model {
+                    Some(format!(
+                        "named:{name}:tokenizer:{}",
+                        configured_tokenizer
+                            .map(|p| identity_hash(p.as_bytes()))
+                            .unwrap_or_else(|| "model-default".into())
+                    ))
+                } else {
+                    artifact_identity(&local.model_path, &local.tokenizer_path)
+                };
+                let trusted = identity.is_some();
+                (
+                    format!(
+                        "local:{}:{:?}:{}",
+                        identity.unwrap_or_else(|| "unavailable".into()),
+                        local.pooling,
+                        local.max_seq_length
+                    ),
+                    trusted,
+                )
+            }
+        };
         Self {
+            model_identity,
+            model_identity_trusted,
             provider,
             local,
             remote,
         }
+    }
+
+    pub fn model_identity(&self) -> &str {
+        &self.model_identity
     }
 
     /// Effective dimensions for the active provider.
@@ -590,7 +676,14 @@ mod tests {
         // Create model.onnx but NOT embedding_model.onnx
         std::fs::write(dir.path().join("model.onnx"), b"fake").unwrap();
         let found = find_onnx_file(dir.path()).unwrap();
-        assert!(found.file_name().unwrap().to_str().unwrap().contains("model.onnx"));
+        assert!(
+            found
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("model.onnx")
+        );
     }
 
     #[test]
@@ -644,8 +737,14 @@ mod tests {
     fn from_shelf_dir_defaults_to_shelf_files() {
         let dir = tempfile::TempDir::new().unwrap();
         let config = EmbeddingConfig::from_shelf_dir(dir.path());
-        assert_eq!(config.local.model_path, dir.path().join("embedding_model.onnx"));
-        assert_eq!(config.local.tokenizer_path, dir.path().join("tokenizer.json"));
+        assert_eq!(
+            config.local.model_path,
+            dir.path().join("embedding_model.onnx")
+        );
+        assert_eq!(
+            config.local.tokenizer_path,
+            dir.path().join("tokenizer.json")
+        );
     }
 
     #[test]
@@ -678,8 +777,22 @@ dimensions = 768
 
         let config = EmbeddingConfig::from_shelf_dir(dir.path());
         assert_eq!(config.local.dimensions, 768);
-        assert!(config.local.model_path.to_str().unwrap().contains("TestOrg"));
-        assert!(config.local.tokenizer_path.to_str().unwrap().contains("TestOrg"));
+        assert!(
+            config
+                .local
+                .model_path
+                .to_str()
+                .unwrap()
+                .contains("TestOrg")
+        );
+        assert!(
+            config
+                .local
+                .tokenizer_path
+                .to_str()
+                .unwrap()
+                .contains("TestOrg")
+        );
 
         // Cleanup
         std::fs::remove_dir_all(model_dir.parent().unwrap().parent().unwrap()).ok();
@@ -698,8 +811,14 @@ dimensions = 512
         std::fs::write(dir.path().join("shelf.toml"), toml_content).unwrap();
 
         let config = EmbeddingConfig::from_shelf_dir(dir.path());
-        assert_eq!(config.local.model_path, PathBuf::from("/custom/path/model.onnx"));
-        assert_eq!(config.local.tokenizer_path, PathBuf::from("/custom/path/tokenizer.json"));
+        assert_eq!(
+            config.local.model_path,
+            PathBuf::from("/custom/path/model.onnx")
+        );
+        assert_eq!(
+            config.local.tokenizer_path,
+            PathBuf::from("/custom/path/tokenizer.json")
+        );
         assert_eq!(config.local.dimensions, 512);
     }
 

--- a/src/embedding/embedder.rs
+++ b/src/embedding/embedder.rs
@@ -38,16 +38,20 @@ mod model_tests {
 
     #[test]
     fn tokenizer_loads() {
-        if !model_available() { return; }
+        if !model_available() {
+            return;
+        }
         let tokenizer_path = shelf_dir().join("tokenizer.json");
-        let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
-            .expect("tokenizer should load");
+        let tokenizer =
+            tokenizers::Tokenizer::from_file(&tokenizer_path).expect("tokenizer should load");
         assert!(tokenizer.get_vocab_size(false) > 0);
     }
 
     #[test]
     fn tokenizer_encodes_multilingual() {
-        if !model_available() { return; }
+        if !model_available() {
+            return;
+        }
         let tokenizer_path = shelf_dir().join("tokenizer.json");
         let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path).unwrap();
 
@@ -60,7 +64,9 @@ mod model_tests {
 
     #[test]
     fn onnx_model_loads_with_ort() {
-        if !model_available() { return; }
+        if !model_available() {
+            return;
+        }
         let model_path = shelf_dir().join("embedding_model.onnx");
         let session = ort::session::Session::builder()
             .expect("builder")
@@ -77,32 +83,46 @@ mod model_tests {
 
     #[test]
     fn embedder_full_pipeline() {
-        if !model_available() { return; }
+        if !model_available() {
+            return;
+        }
         let embedder = make_provider();
         assert!(embedder.is_available());
 
-        let vector = embedder.embed("Hello, world! 你好世界").expect("embed should succeed");
+        let vector = embedder
+            .embed("Hello, world! 你好世界")
+            .expect("embed should succeed");
         assert!(!vector.is_empty(), "embedding should not be empty");
 
         let norm: f32 = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
-        assert!((norm - 1.0).abs() < 0.01, "L2 norm should be ~1.0, got {norm}");
+        assert!(
+            (norm - 1.0).abs() < 0.01,
+            "L2 norm should be ~1.0, got {norm}"
+        );
     }
 
     #[test]
     fn embedder_semantic_similarity() {
-        if !model_available() { return; }
+        if !model_available() {
+            return;
+        }
         let embedder = make_provider();
 
         let v_cat = embedder.embed("The cat sat on the mat").unwrap();
         let v_kitten = embedder.embed("A kitten is sitting on a rug").unwrap();
-        let v_code = embedder.embed("Rust programming language compiler").unwrap();
+        let v_code = embedder
+            .embed("Rust programming language compiler")
+            .unwrap();
 
         let sim_sim = cosine_similarity(&v_cat, &v_kitten);
         let sim_diff = cosine_similarity(&v_cat, &v_code);
 
         eprintln!("cat vs kitten similarity: {sim_sim:.4}");
         eprintln!("cat vs code similarity:   {sim_diff:.4}");
-        assert!(sim_sim > sim_diff, "semantically similar texts should have higher cosine similarity");
+        assert!(
+            sim_sim > sim_diff,
+            "semantically similar texts should have higher cosine similarity"
+        );
     }
 
     fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {

--- a/src/embedding/provider.rs
+++ b/src/embedding/provider.rs
@@ -5,8 +5,8 @@ use ndarray::Array2;
 use ort::session::Session;
 use ort::value::TensorRef;
 
-use crate::error::HypatiaError;
 use super::config::{EmbeddingConfig, LocalConfig, PoolingStrategy, ProviderKind, RemoteConfig};
+use crate::error::HypatiaError;
 
 /// Trait for embedding providers (local ONNX or remote API).
 pub trait EmbeddingProvider {
@@ -49,8 +49,13 @@ pub struct OnnxProvider {
 
 #[allow(clippy::large_enum_variant)]
 enum OnnxInner {
-    Unavailable { reason: String },
-    Pending { model_path: std::path::PathBuf, tokenizer_path: std::path::PathBuf },
+    Unavailable {
+        reason: String,
+    },
+    Pending {
+        model_path: std::path::PathBuf,
+        tokenizer_path: std::path::PathBuf,
+    },
     Ready {
         session: Session,
         tokenizer: tokenizers::Tokenizer,
@@ -105,26 +110,29 @@ impl OnnxProvider {
             let mut inner = self.inner.borrow_mut();
             let old = std::mem::replace(
                 &mut *inner,
-                OnnxInner::Unavailable { reason: "loading...".to_string() },
+                OnnxInner::Unavailable {
+                    reason: "loading...".to_string(),
+                },
             );
 
             match old {
-                OnnxInner::Pending { model_path, tokenizer_path } => {
-                    match load_onnx_model(&model_path, &tokenizer_path) {
-                        Ok((session, tokenizer)) => {
-                            *inner = OnnxInner::Ready { session, tokenizer };
-                            Ok(())
-                        }
-                        Err(e) => {
-                            *inner = OnnxInner::Unavailable {
-                                reason: format!("failed to load model: {e}"),
-                            };
-                            Err(HypatiaError::Embedding(format!(
-                                "failed to load ONNX model: {e}"
-                            )))
-                        }
+                OnnxInner::Pending {
+                    model_path,
+                    tokenizer_path,
+                } => match load_onnx_model(&model_path, &tokenizer_path) {
+                    Ok((session, tokenizer)) => {
+                        *inner = OnnxInner::Ready { session, tokenizer };
+                        Ok(())
                     }
-                }
+                    Err(e) => {
+                        *inner = OnnxInner::Unavailable {
+                            reason: format!("failed to load model: {e}"),
+                        };
+                        Err(HypatiaError::Embedding(format!(
+                            "failed to load ONNX model: {e}"
+                        )))
+                    }
+                },
                 other => {
                     *inner = other;
                     Ok(())
@@ -142,9 +150,9 @@ impl EmbeddingProvider for OnnxProvider {
 
         let mut inner = self.inner.borrow_mut();
         match &mut *inner {
-            OnnxInner::Ready { session, tokenizer, .. } => {
-                run_onnx_inference(session, tokenizer, text, self.max_seq_length, self.pooling)
-            }
+            OnnxInner::Ready {
+                session, tokenizer, ..
+            } => run_onnx_inference(session, tokenizer, text, self.max_seq_length, self.pooling),
             _ => unreachable!("ensure_loaded should guarantee Ready state"),
         }
     }
@@ -203,16 +211,21 @@ fn run_onnx_inference(
     let input_ids_array = Array2::from_shape_vec((1, seq_len), input_ids_data)
         .map_err(|e| HypatiaError::Embedding(format!("failed to create input_ids array: {e}")))?;
 
-    let attention_mask_array = Array2::from_shape_vec((1, seq_len), attention_mask_data)
-        .map_err(|e| HypatiaError::Embedding(format!("failed to create attention_mask array: {e}")))?;
+    let attention_mask_array =
+        Array2::from_shape_vec((1, seq_len), attention_mask_data).map_err(|e| {
+            HypatiaError::Embedding(format!("failed to create attention_mask array: {e}"))
+        })?;
 
     let input_ids_tensor = TensorRef::from_array_view(input_ids_array.view())
         .map_err(|e| HypatiaError::Embedding(format!("failed to create input_ids tensor: {e}")))?;
 
-    let attention_mask_tensor = TensorRef::from_array_view(attention_mask_array.view())
-        .map_err(|e| HypatiaError::Embedding(format!("failed to create attention_mask tensor: {e}")))?;
+    let attention_mask_tensor =
+        TensorRef::from_array_view(attention_mask_array.view()).map_err(|e| {
+            HypatiaError::Embedding(format!("failed to create attention_mask tensor: {e}"))
+        })?;
 
-    let outputs = session.run(ort::inputs![input_ids_tensor, attention_mask_tensor])
+    let outputs = session
+        .run(ort::inputs![input_ids_tensor, attention_mask_tensor])
         .map_err(|e| HypatiaError::Embedding(format!("inference failed: {e}")))?;
 
     // Prefer sentence_embedding (index 1) if available, else token_embeddings (index 0)
@@ -341,15 +354,15 @@ impl RemoteApiProvider {
 
     fn api_key(&self) -> Result<String, HypatiaError> {
         std::env::var(&self.api_key_env).map_err(|_| {
-            HypatiaError::Embedding(format!(
-                "environment variable {} not set",
-                self.api_key_env
-            ))
+            HypatiaError::Embedding(format!("environment variable {} not set", self.api_key_env))
         })
     }
 
     /// Send an embedding request with timeout and retry.
-    fn request_with_retry(&self, input: &serde_json::Value) -> Result<serde_json::Value, HypatiaError> {
+    fn request_with_retry(
+        &self,
+        input: &serde_json::Value,
+    ) -> Result<serde_json::Value, HypatiaError> {
         let api_key = self.api_key()?;
 
         let mut request_body = serde_json::json!({
@@ -365,9 +378,8 @@ impl RemoteApiProvider {
 
         for attempt in 0..=MAX_RETRIES {
             if attempt > 0 {
-                let delay = std::time::Duration::from_millis(
-                    RETRY_BASE_DELAY_MS * 2u64.pow(attempt - 1),
-                );
+                let delay =
+                    std::time::Duration::from_millis(RETRY_BASE_DELAY_MS * 2u64.pow(attempt - 1));
                 eprintln!(
                     "    [remote-embed] retry {attempt}/{MAX_RETRIES} after {}ms",
                     delay.as_millis()
@@ -394,15 +406,13 @@ impl RemoteApiProvider {
                             continue;
                         }
                         return Err(HypatiaError::Embedding(format!(
-                            "API returned {}: {msg}", status
+                            "API returned {}: {msg}",
+                            status
                         )));
                     }
-                    let body: serde_json::Value = response
-                        .body_mut()
-                        .read_json()
-                        .map_err(|e| HypatiaError::Embedding(format!(
-                            "failed to parse API response: {e}"
-                        )))?;
+                    let body: serde_json::Value = response.body_mut().read_json().map_err(|e| {
+                        HypatiaError::Embedding(format!("failed to parse API response: {e}"))
+                    })?;
                     return Ok(body);
                 }
                 Err(e) => {
@@ -420,15 +430,16 @@ impl RemoteApiProvider {
     }
 
     /// Parse a single embedding from the API response.
-    fn parse_embedding(response: &serde_json::Value, index: usize) -> Result<Vec<f32>, HypatiaError> {
+    fn parse_embedding(
+        response: &serde_json::Value,
+        index: usize,
+    ) -> Result<Vec<f32>, HypatiaError> {
         let embedding = response
             .get("data")
             .and_then(|d| d.get(index))
             .and_then(|d| d.get("embedding"))
             .and_then(|e| e.as_array())
-            .ok_or_else(|| {
-                HypatiaError::Embedding("unexpected API response format".into())
-            })?;
+            .ok_or_else(|| HypatiaError::Embedding("unexpected API response format".into()))?;
 
         let vector: Vec<f32> = embedding
             .iter()

--- a/src/engine/evaluator.rs
+++ b/src/engine/evaluator.rs
@@ -1,10 +1,10 @@
-use crate::error::{HypatiaError, Result};
-use crate::model::{QueryOpts, QueryResult, QueryTarget, SearchOpts};
-use crate::storage::Storage;
 use super::ast::AstNode;
 use super::operators::{OpContext, OperatorResult};
 use super::parser::Parser;
 use super::sql_builder::SqlBuilder;
+use crate::error::{HypatiaError, Result};
+use crate::model::{QueryOpts, QueryResult, QueryTarget, SearchOpts};
+use crate::storage::Storage;
 
 pub struct Evaluator;
 
@@ -12,6 +12,9 @@ impl Evaluator {
     /// Parse a JSE JSON expression and evaluate it against storage.
     pub fn execute(json: &serde_json::Value, store: &dyn Storage) -> Result<QueryResult> {
         let ast = Parser::parse(json)?;
+        if store.sql_dialect() == super::SqlDialect::Postgres {
+            return super::postgres::execute(&ast, store);
+        }
         Self::eval(&ast, store)
     }
 
@@ -60,7 +63,9 @@ impl Evaluator {
                     // the resulting keys to build SQL IN conditions.
                     let search_opts = query_opts_to_search_opts(&opts, target);
                     let search_result = store.execute_search(&query, &search_opts)?;
-                    let keys: Vec<String> = search_result.rows.iter()
+                    let keys: Vec<String> = search_result
+                        .rows
+                        .iter()
                         .filter_map(|row| row.get("key").and_then(|v| v.as_str()).map(String::from))
                         .collect();
                     if keys.is_empty() {
@@ -76,8 +81,14 @@ impl Evaluator {
                     // to build SQL IN conditions (same pattern as FTS).
                     let search_opts = query_opts_to_search_opts(&opts, target);
                     let search_result = store.execute_similar(&query_text, &search_opts, target)?;
-                    let keys: Vec<String> = search_result.rows.iter()
-                        .filter_map(|row| row.get(target.key_column()).and_then(|v| v.as_str()).map(String::from))
+                    let keys: Vec<String> = search_result
+                        .rows
+                        .iter()
+                        .filter_map(|row| {
+                            row.get(target.key_column())
+                                .and_then(|v| v.as_str())
+                                .map(String::from)
+                        })
                         .collect();
                     if keys.is_empty() {
                         builder.add_condition("1=0".to_string(), Vec::new());
@@ -86,7 +97,11 @@ impl Evaluator {
                         builder.add_condition(fragment, params);
                     }
                 }
-                OperatorResult::KHop { subject, predicate, depth } => {
+                OperatorResult::KHop {
+                    subject,
+                    predicate,
+                    depth,
+                } => {
                     // $k-hop: only valid inside $statement
                     if target != QueryTarget::Statement {
                         return Err(HypatiaError::Eval(
@@ -94,8 +109,12 @@ impl Evaluator {
                         ));
                     }
                     let khop_result = store.execute_khop(&subject, predicate.as_deref(), depth)?;
-                    let keys: Vec<String> = khop_result.rows.iter()
-                        .filter_map(|row| row.get("triple").and_then(|v| v.as_str()).map(String::from))
+                    let keys: Vec<String> = khop_result
+                        .rows
+                        .iter()
+                        .filter_map(|row| {
+                            row.get("triple").and_then(|v| v.as_str()).map(String::from)
+                        })
                         .collect();
                     if keys.is_empty() {
                         builder.add_condition("1=0".to_string(), Vec::new());
@@ -123,7 +142,8 @@ impl Evaluator {
 
         if operands.is_empty() {
             return Err(HypatiaError::Eval(
-                "$not-summaried expects at least a tag argument (e.g. \"message\", \"summary-l1\")".to_string(),
+                "$not-summaried expects at least a tag argument (e.g. \"message\", \"summary-l1\")"
+                    .to_string(),
             ));
         }
 
@@ -155,27 +175,36 @@ impl Evaluator {
                 OperatorResult::FtsQuery { query } => {
                     let search_opts = query_opts_to_search_opts(&opts, QueryTarget::Knowledge);
                     let search_result = store.execute_search(&query, &search_opts)?;
-                    let keys: Vec<String> = search_result.rows.iter()
+                    let keys: Vec<String> = search_result
+                        .rows
+                        .iter()
                         .filter_map(|row| row.get("key").and_then(|v| v.as_str()).map(String::from))
                         .collect();
                     if keys.is_empty() {
                         conditions.push("1=0".to_string());
                     } else {
-                        let (fragment, params) = build_key_match_condition(QueryTarget::Knowledge, &keys);
+                        let (fragment, params) =
+                            build_key_match_condition(QueryTarget::Knowledge, &keys);
                         conditions.push(fragment);
                         cond_params.extend(params);
                     }
                 }
                 OperatorResult::VectorQuery { query_text } => {
                     let search_opts = query_opts_to_search_opts(&opts, QueryTarget::Knowledge);
-                    let search_result = store.execute_similar(&query_text, &search_opts, QueryTarget::Knowledge)?;
-                    let keys: Vec<String> = search_result.rows.iter()
-                        .filter_map(|row| row.get("name").and_then(|v| v.as_str()).map(String::from))
+                    let search_result =
+                        store.execute_similar(&query_text, &search_opts, QueryTarget::Knowledge)?;
+                    let keys: Vec<String> = search_result
+                        .rows
+                        .iter()
+                        .filter_map(|row| {
+                            row.get("name").and_then(|v| v.as_str()).map(String::from)
+                        })
                         .collect();
                     if keys.is_empty() {
                         conditions.push("1=0".to_string());
                     } else {
-                        let (fragment, params) = build_key_match_condition(QueryTarget::Knowledge, &keys);
+                        let (fragment, params) =
+                            build_key_match_condition(QueryTarget::Knowledge, &keys);
                         conditions.push(fragment);
                         cond_params.extend(params);
                     }
@@ -222,27 +251,26 @@ impl Evaluator {
 
     fn eval_condition(ast: &AstNode, ctx: &OpContext) -> Result<OperatorResult> {
         match ast {
-            AstNode::Operator { operator, operands, metadata } => {
-                super::operators::evaluate_operator(
-                    operator,
-                    operands,
-                    metadata,
-                    ctx,
-                    &|node| Self::eval_condition(node, ctx),
-                )
-            }
-            AstNode::Quote(inner) => {
-                Ok(OperatorResult::Value(ast_to_value(inner)))
-            }
+            AstNode::Operator {
+                operator,
+                operands,
+                metadata,
+            } => super::operators::evaluate_operator(operator, operands, metadata, ctx, &|node| {
+                Self::eval_condition(node, ctx)
+            }),
+            AstNode::Quote(inner) => Ok(OperatorResult::Value(ast_to_value(inner))),
             AstNode::Literal(v) => Ok(OperatorResult::Value(v.clone())),
             _ => Err(HypatiaError::Eval(format!(
-                "unexpected node in condition context: {:?}", ast
+                "unexpected node in condition context: {:?}",
+                ast
             ))),
         }
     }
 }
 
-fn extract_query_opts(metadata: &serde_json::Map<String, serde_json::Value>) -> QueryOpts {
+pub(super) fn extract_query_opts(
+    metadata: &serde_json::Map<String, serde_json::Value>,
+) -> QueryOpts {
     let mut opts = QueryOpts::default();
     if let Some(serde_json::Value::String(catalog)) = metadata.get("catalog") {
         opts.catalog = Some(catalog.clone());
@@ -257,10 +285,13 @@ fn extract_query_opts(metadata: &serde_json::Map<String, serde_json::Value>) -> 
 }
 
 /// Convert QueryOpts (from the parent $knowledge/$statement) to SearchOpts for FTS execution.
-fn query_opts_to_search_opts(opts: &QueryOpts, target: QueryTarget) -> SearchOpts {
+pub(super) fn query_opts_to_search_opts(opts: &QueryOpts, target: QueryTarget) -> SearchOpts {
     SearchOpts {
         // Default catalog to the query target's table name if not explicitly set
-        catalog: opts.catalog.clone().or_else(|| Some(target.table_name().to_string())),
+        catalog: opts
+            .catalog
+            .clone()
+            .or_else(|| Some(target.table_name().to_string())),
         limit: opts.limit,
         offset: opts.offset,
     }
@@ -269,9 +300,13 @@ fn query_opts_to_search_opts(opts: &QueryOpts, target: QueryTarget) -> SearchOpt
 /// Build a SQL condition that matches keys from FTS results against the target table.
 /// For Knowledge: `name IN (?, ?, ...)`
 /// For Statement: `triple IN (?, ?, ...)`
-fn build_key_match_condition(target: QueryTarget, keys: &[String]) -> (String, Vec<serde_json::Value>) {
+fn build_key_match_condition(
+    target: QueryTarget,
+    keys: &[String],
+) -> (String, Vec<serde_json::Value>) {
     let pk_column = target.key_column();
-    let params: Vec<serde_json::Value> = keys.iter()
+    let params: Vec<serde_json::Value> = keys
+        .iter()
         .map(|k| serde_json::Value::String(k.clone()))
         .collect();
     let placeholders: Vec<&str> = keys.iter().map(|_| "?").collect();
@@ -280,16 +315,16 @@ fn build_key_match_condition(target: QueryTarget, keys: &[String]) -> (String, V
 }
 
 /// Convert an AST node back to a JSON value (for $quote).
-fn ast_to_value(node: &AstNode) -> serde_json::Value {
+pub(super) fn ast_to_value(node: &AstNode) -> serde_json::Value {
     match node {
         AstNode::Literal(v) => v.clone(),
         AstNode::Symbol(s) => serde_json::Value::String(s.clone()),
-        AstNode::Array(nodes) => {
-            serde_json::Value::Array(nodes.iter().map(ast_to_value).collect())
-        }
+        AstNode::Array(nodes) => serde_json::Value::Array(nodes.iter().map(ast_to_value).collect()),
         AstNode::Object(map) => serde_json::Value::Object(map.clone()),
         AstNode::Quote(_inner) => ast_to_value(_inner),
-        AstNode::Operator { operator, operands, .. } => {
+        AstNode::Operator {
+            operator, operands, ..
+        } => {
             let mut arr = vec![serde_json::Value::String(operator.clone())];
             arr.extend(operands.iter().map(ast_to_value));
             serde_json::Value::Array(arr)
@@ -320,7 +355,10 @@ mod tests {
             query_results: Vec<serde_json::Map<String, serde_json::Value>>,
             search_results: Vec<serde_json::Map<String, serde_json::Value>>,
         ) -> Self {
-            Self { query_results, search_results }
+            Self {
+                query_results,
+                search_results,
+            }
         }
     }
 
@@ -366,10 +404,8 @@ mod tests {
             m.insert("name".to_string(), json!("test"));
             m
         }]);
-        let result = Evaluator::execute(
-            &json!(["$knowledge", ["$eq", "name", "test"]]),
-            &mock,
-        ).unwrap();
+        let result =
+            Evaluator::execute(&json!(["$knowledge", ["$eq", "name", "test"]]), &mock).unwrap();
         assert_eq!(result.rows.len(), 1);
         assert_eq!(result.rows[0]["name"], json!("test"));
     }
@@ -377,10 +413,7 @@ mod tests {
     #[test]
     fn eval_statement_query() {
         let mock = MockStorage::new(vec![]);
-        let result = Evaluator::execute(
-            &json!(["$statement"]),
-            &mock,
-        ).unwrap();
+        let result = Evaluator::execute(&json!(["$statement"]), &mock).unwrap();
         assert_eq!(result.rows.len(), 0);
     }
 
@@ -395,10 +428,8 @@ mod tests {
         query_row.insert("name".to_string(), json!("rust"));
 
         let mock = MockStorage::with_search_results(vec![query_row], vec![search_row]);
-        let result = Evaluator::execute(
-            &json!(["$knowledge", ["$search", "rust"]]),
-            &mock,
-        ).unwrap();
+        let result =
+            Evaluator::execute(&json!(["$knowledge", ["$search", "rust"]]), &mock).unwrap();
         assert_eq!(result.rows.len(), 1);
         assert_eq!(result.rows[0]["name"], json!("rust"));
     }
@@ -415,10 +446,8 @@ mod tests {
         query_row.insert("triple".to_string(), json!("Alice,knows,Bob"));
 
         let mock = MockStorage::with_search_results(vec![query_row], vec![search_row]);
-        let result = Evaluator::execute(
-            &json!(["$statement", ["$search", "Alice"]]),
-            &mock,
-        ).unwrap();
+        let result =
+            Evaluator::execute(&json!(["$statement", ["$search", "Alice"]]), &mock).unwrap();
         assert_eq!(result.rows.len(), 1);
     }
 
@@ -426,20 +455,14 @@ mod tests {
     fn eval_search_not_top_level() {
         // $search can no longer be used as a top-level operator
         let mock = MockStorage::new(vec![]);
-        let result = Evaluator::execute(
-            &json!({"$search": "rust", "catalog": "knowledge"}),
-            &mock,
-        );
+        let result = Evaluator::execute(&json!({"$search": "rust", "catalog": "knowledge"}), &mock);
         assert!(result.is_err());
     }
 
     #[test]
     fn eval_invalid_top_level() {
         let mock = MockStorage::new(vec![]);
-        let result = Evaluator::execute(
-            &json!("not a query"),
-            &mock,
-        );
+        let result = Evaluator::execute(&json!("not a query"), &mock);
         assert!(result.is_err());
     }
 
@@ -457,7 +480,8 @@ mod tests {
         let result = Evaluator::execute(
             &json!(["$knowledge", ["$similar", "systems programming"]]),
             &mock,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(result.rows.len(), 1);
         assert_eq!(result.rows[0]["name"], json!("rust"));
     }
@@ -473,10 +497,9 @@ mod tests {
         query_row.insert("triple".to_string(), json!("Alice,knows,Bob"));
 
         let mock = MockStorage::with_search_results(vec![query_row], vec![similar_row]);
-        let result = Evaluator::execute(
-            &json!(["$statement", ["$similar", "relationships"]]),
-            &mock,
-        ).unwrap();
+        let result =
+            Evaluator::execute(&json!(["$statement", ["$similar", "relationships"]]), &mock)
+                .unwrap();
         assert_eq!(result.rows.len(), 1);
     }
 
@@ -494,7 +517,10 @@ mod tests {
     fn build_key_match_statement() {
         let (sql, params) = build_key_match_condition(
             QueryTarget::Statement,
-            &["Alice,knows,Bob".to_string(), "Charlie,likes,Rust".to_string()],
+            &[
+                "Alice,knows,Bob".to_string(),
+                "Charlie,likes,Rust".to_string(),
+            ],
         );
         assert_eq!(sql, "triple IN (?, ?)");
         assert_eq!(params.len(), 2);
@@ -504,14 +530,14 @@ mod tests {
     fn eval_not_summaried_basic() {
         let mut row = serde_json::Map::new();
         row.insert("name".to_string(), json!("msg-s1-001"));
-        row.insert("content".to_string(), json!(r#"{"tags":["message","user"]}"#));
+        row.insert(
+            "content".to_string(),
+            json!(r#"{"tags":["message","user"]}"#),
+        );
         row.insert("created_at".to_string(), json!("2026-01-01 00:00:00"));
 
         let mock = MockStorage::new(vec![row]);
-        let result = Evaluator::execute(
-            &json!(["$not-summaried", "message"]),
-            &mock,
-        ).unwrap();
+        let result = Evaluator::execute(&json!(["$not-summaried", "message"]), &mock).unwrap();
         assert_eq!(result.rows.len(), 1);
         assert_eq!(result.rows[0]["name"], json!("msg-s1-001"));
     }
@@ -520,37 +546,49 @@ mod tests {
     fn eval_not_summaried_with_condition() {
         let mut row = serde_json::Map::new();
         row.insert("name".to_string(), json!("msg-s1-001"));
-        row.insert("content".to_string(), json!(r#"{"tags":["message","user"]}"#));
+        row.insert(
+            "content".to_string(),
+            json!(r#"{"tags":["message","user"]}"#),
+        );
         row.insert("created_at".to_string(), json!("2026-01-01 00:00:00"));
 
         let mock = MockStorage::new(vec![row]);
         let result = Evaluator::execute(
-            &json!(["$not-summaried", "message", ["$contains", "scopes", "my-project"]]),
+            &json!([
+                "$not-summaried",
+                "message",
+                ["$contains", "scopes", "my-project"]
+            ]),
             &mock,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(result.rows.len(), 1);
     }
 
     #[test]
     fn eval_not_summaried_empty_operands() {
         let mock = MockStorage::new(vec![]);
-        let result = Evaluator::execute(
-            &json!(["$not-summaried"]),
-            &mock,
-        );
+        let result = Evaluator::execute(&json!(["$not-summaried"]), &mock);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("expects at least a tag"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("expects at least a tag")
+        );
     }
 
     #[test]
     fn eval_not_summaried_bad_tag() {
         let mock = MockStorage::new(vec![]);
-        let result = Evaluator::execute(
-            &json!(["$not-summaried", 123]),
-            &mock,
-        );
+        let result = Evaluator::execute(&json!(["$not-summaried", 123]), &mock);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("must be a tag string"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must be a tag string")
+        );
     }
 
     /// Build the SQL fragment an operator emits under a qualifying context,
@@ -615,7 +653,12 @@ mod tests {
     /// a valid path that silently matched nothing.
     #[test]
     fn qualified_context_does_not_rewrite_column_names_inside_field_paths() {
-        for field in ["doc_created_at", "created_at_utc", "tr_start_ns", "my_tr_end"] {
+        for field in [
+            "doc_created_at",
+            "created_at_utc",
+            "tr_start_ns",
+            "my_tr_end",
+        ] {
             let (fragment, params) = qualified_fragment(json!(["$like", field, "%x%"]));
             assert_eq!(
                 fragment, "json_extract(knowledge.content, ?) LIKE ?",

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2,6 +2,8 @@ pub mod ast;
 pub mod evaluator;
 pub mod operators;
 pub mod parser;
+pub mod postgres;
 pub mod sql_builder;
+pub use sql_builder::SqlDialect;
 
 pub use evaluator::Evaluator;

--- a/src/engine/operators.rs
+++ b/src/engine/operators.rs
@@ -1,5 +1,5 @@
-use crate::error::{HypatiaError, Result};
 use super::ast::AstNode;
+use crate::error::{HypatiaError, Result};
 
 /// Result of evaluating an operator in the context of query building.
 #[derive(Debug, Clone)]
@@ -10,13 +10,9 @@ pub enum OperatorResult {
         params: Vec<serde_json::Value>,
     },
     /// A FTS search query string. Opts are inherited from the parent query.
-    FtsQuery {
-        query: String,
-    },
+    FtsQuery { query: String },
     /// A semantic similarity query. The evaluator embeds the text and searches vectors.
-    VectorQuery {
-        query_text: String,
-    },
+    VectorQuery { query_text: String },
     /// A k-hop forward graph traversal query on the statement graph.
     KHop {
         subject: String,
@@ -70,7 +66,10 @@ impl OpContext {
     /// construction time, is what keeps the caller from having to rewrite
     /// finished SQL by textual substitution.
     pub fn qualified(self) -> Self {
-        Self { qualify_columns: true, ..self }
+        Self {
+            qualify_columns: true,
+            ..self
+        }
     }
 
     /// Render a column reference, qualifying it when it would be ambiguous.
@@ -88,7 +87,11 @@ impl OpContext {
 const ARRAY_FIELDS: &[&str] = &["tags", "scopes", "figures", "synonyms"];
 
 /// Correlated membership predicate: the document's json_index has (path, token).
-fn membership_fragment(ctx: &OpContext, path: &str, token: &str) -> (String, Vec<serde_json::Value>) {
+fn membership_fragment(
+    ctx: &OpContext,
+    path: &str,
+    token: &str,
+) -> (String, Vec<serde_json::Value>) {
     (
         format!(
             "EXISTS (SELECT 1 FROM docs d JOIN json_index j ON j.doc_id = d.id \
@@ -105,16 +108,14 @@ fn membership_fragment(ctx: &OpContext, path: &str, token: &str) -> (String, Vec
 /// Depth-first first-scalar-leaf of a JSON value, for @> recall narrowing.
 fn first_leaf(v: &serde_json::Value, path: &str) -> Option<(String, String)> {
     match v {
-        serde_json::Value::Object(m) => m
-            .iter()
-            .find_map(|(k, rv)| {
-                let child = if path.is_empty() {
-                    k.to_string()
-                } else {
-                    format!("{path}.{k}")
-                };
-                first_leaf(rv, &child)
-            }),
+        serde_json::Value::Object(m) => m.iter().find_map(|(k, rv)| {
+            let child = if path.is_empty() {
+                k.to_string()
+            } else {
+                format!("{path}.{k}")
+            };
+            first_leaf(rv, &child)
+        }),
         serde_json::Value::Array(e) => e.iter().find_map(|rv| first_leaf(rv, path)),
         other => crate::storage::json_index::scalar_token(other).map(|t| (path.to_string(), t)),
     }
@@ -154,7 +155,8 @@ pub fn evaluate_operator(
                     }
                     other => {
                         return Err(HypatiaError::Eval(format!(
-                            "$and expects SQL conditions, got {:?}", other
+                            "$and expects SQL conditions, got {:?}",
+                            other
                         )));
                     }
                 }
@@ -187,7 +189,8 @@ pub fn evaluate_operator(
                     }
                     other => {
                         return Err(HypatiaError::Eval(format!(
-                            "$or expects SQL conditions, got {:?}", other
+                            "$or expects SQL conditions, got {:?}",
+                            other
                         )));
                     }
                 }
@@ -206,7 +209,9 @@ pub fn evaluate_operator(
         }
         "$not" => {
             if operands.len() != 1 {
-                return Err(HypatiaError::Eval("$not expects exactly one argument".to_string()));
+                return Err(HypatiaError::Eval(
+                    "$not expects exactly one argument".to_string(),
+                ));
             }
             match eval_fn(&operands[0])? {
                 OperatorResult::SqlCondition { fragment, params } => {
@@ -216,7 +221,8 @@ pub fn evaluate_operator(
                     })
                 }
                 other => Err(HypatiaError::Eval(format!(
-                    "$not expects SQL condition, got {:?}", other
+                    "$not expects SQL condition, got {:?}",
+                    other
                 ))),
             }
         }
@@ -272,7 +278,9 @@ pub fn evaluate_operator(
             let mut params = Vec::new();
             for v in &values {
                 let token = crate::storage::json_index::scalar_token(v).ok_or_else(|| {
-                    HypatiaError::Eval("$has value must be a scalar or array of scalars".to_string())
+                    HypatiaError::Eval(
+                        "$has value must be a scalar or array of scalars".to_string(),
+                    )
                 })?;
                 let (f, mut p) = membership_fragment(ctx, &field, &token);
                 params.append(&mut p);
@@ -342,7 +350,7 @@ pub fn evaluate_operator(
                 _ => {
                     return Err(HypatiaError::Eval(
                         "$content expects a JSON object".to_string(),
-                    ))
+                    ));
                 }
             };
             if map.is_empty() {
@@ -358,8 +366,7 @@ pub fn evaluate_operator(
                     serde_json::Value::String(s) => s.clone(),
                     other => other.to_string(),
                 };
-                let token = crate::storage::json_index::scalar_token(val)
-                    .unwrap_or(str_val);
+                let token = crate::storage::json_index::scalar_token(val).unwrap_or(str_val);
                 let (f, mut p) = membership_fragment(ctx, key, &token);
                 fragments.push(f);
                 params.append(&mut p);
@@ -371,7 +378,9 @@ pub fn evaluate_operator(
         }
         "$search" => {
             let query = if operands.is_empty() {
-                return Err(HypatiaError::Eval("$search expects a query argument".to_string()));
+                return Err(HypatiaError::Eval(
+                    "$search expects a query argument".to_string(),
+                ));
             } else {
                 expect_literal(&operands[0])?
             };
@@ -379,13 +388,13 @@ pub fn evaluate_operator(
                 serde_json::Value::String(s) => s.clone(),
                 other => other.to_string(),
             };
-            Ok(OperatorResult::FtsQuery {
-                query: query_str,
-            })
+            Ok(OperatorResult::FtsQuery { query: query_str })
         }
         "$similar" => {
             let query = if operands.is_empty() {
-                return Err(HypatiaError::Eval("$similar expects a query argument".to_string()));
+                return Err(HypatiaError::Eval(
+                    "$similar expects a query argument".to_string(),
+                ));
             } else {
                 expect_literal(&operands[0])?
             };
@@ -433,9 +442,9 @@ pub fn evaluate_operator(
             let depth_val = expect_literal(&operands[2])?;
             let depth = match &depth_val {
                 serde_json::Value::Number(n) => {
-                    let d = n.as_i64().ok_or_else(|| HypatiaError::Eval(
-                        "$k-hop depth must be an integer".to_string(),
-                    ))?;
+                    let d = n.as_i64().ok_or_else(|| {
+                        HypatiaError::Eval("$k-hop depth must be an integer".to_string())
+                    })?;
                     if d <= 0 {
                         return Err(HypatiaError::Eval(
                             "$k-hop depth must be a positive integer".to_string(),
@@ -449,11 +458,17 @@ pub fn evaluate_operator(
                     ));
                 }
             };
-            Ok(OperatorResult::KHop { subject, predicate, depth })
+            Ok(OperatorResult::KHop {
+                subject,
+                predicate,
+                depth,
+            })
         }
         "$quote" => {
             if operands.len() != 1 {
-                return Err(HypatiaError::Eval("$quote expects exactly one argument".to_string()));
+                return Err(HypatiaError::Eval(
+                    "$quote expects exactly one argument".to_string(),
+                ));
             }
             // Return the unevaluated operand as a literal value
             Ok(OperatorResult::Value(ast_to_value(&operands[0])))
@@ -465,8 +480,9 @@ pub fn evaluate_operator(
                 ));
             }
             // Parse each operand: "$*" means wildcard (None), otherwise exact match
-            let patterns: Vec<Option<String>> = operands.iter().map(|op| {
-                match op {
+            let patterns: Vec<Option<String>> = operands
+                .iter()
+                .map(|op| match op {
                     AstNode::Symbol(s) if s == "$*" => Ok(None),
                     AstNode::Literal(serde_json::Value::String(s)) if s == "$*" => Ok(None),
                     other => {
@@ -478,8 +494,8 @@ pub fn evaluate_operator(
                             )),
                         }
                     }
-                }
-            }).collect::<Result<Vec<_>>>()?;
+                })
+                .collect::<Result<Vec<_>>>()?;
 
             // Error: all wildcards is a no-op
             if patterns.iter().all(|p| p.is_none()) {
@@ -562,7 +578,8 @@ fn comparison_op(
         eval_fn(&operands[0])
     } else {
         Err(HypatiaError::Eval(format!(
-            "comparison operator expects 1 or 2 arguments, got {}", operands.len()
+            "comparison operator expects 1 or 2 arguments, got {}",
+            operands.len()
         )))
     }
 }
@@ -573,7 +590,8 @@ fn expect_symbol(node: &AstNode) -> Result<String> {
         AstNode::Symbol(s) => Ok(s.clone()),
         AstNode::Literal(serde_json::Value::String(s)) => Ok(s.clone()),
         _ => Err(HypatiaError::Eval(format!(
-            "expected symbol or string, got {:?}", node
+            "expected symbol or string, got {:?}",
+            node
         ))),
     }
 }
@@ -590,7 +608,14 @@ fn expect_literal(node: &AstNode) -> Result<serde_json::Value> {
 /// Field names that address a real table column rather than a Content
 /// JSON path.
 const COLUMN_FIELDS: &[&str] = &[
-    "head", "relation", "tail", "triple", "name", "created_at", "tr_start", "tr_end",
+    "head",
+    "relation",
+    "tail",
+    "triple",
+    "name",
+    "created_at",
+    "tr_start",
+    "tr_end",
 ];
 
 /// A field reference rendered as SQL, plus the bindings its placeholders need.
@@ -608,7 +633,10 @@ struct ResolvedField {
 
 impl ResolvedField {
     /// Combine with the operator's value parameters, keeping placeholder order.
-    fn with_values(self, values: impl IntoIterator<Item = serde_json::Value>) -> Vec<serde_json::Value> {
+    fn with_values(
+        self,
+        values: impl IntoIterator<Item = serde_json::Value>,
+    ) -> Vec<serde_json::Value> {
         let mut params = self.params;
         params.extend(values);
         params
@@ -620,7 +648,7 @@ impl ResolvedField {
 /// The path is bound as a parameter rather than interpolated, so this check is
 /// defense in depth. It exists so a malformed name fails loudly at the field
 /// instead of producing a JSON path that silently matches nothing.
-fn validate_field_path(field: &str) -> Result<()> {
+pub(super) fn validate_field_path(field: &str) -> Result<()> {
     let invalid = || {
         HypatiaError::Validation(format!(
             "invalid field name {field:?}: expected a JSON path such as \
@@ -635,7 +663,11 @@ fn validate_field_path(field: &str) -> Result<()> {
             Some(i) => segment.split_at(i),
             None => (segment, ""),
         };
-        if name.is_empty() || !name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-') {
+        if name.is_empty()
+            || !name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        {
             return Err(invalid());
         }
         // Trailing array subscripts: `[0]`, `[0][1]`.
@@ -689,12 +721,14 @@ fn ast_to_value(node: &AstNode) -> serde_json::Value {
     match node {
         AstNode::Literal(v) => v.clone(),
         AstNode::Symbol(s) => serde_json::Value::String(s.clone()),
-        AstNode::Array(nodes) => {
-            serde_json::Value::Array(nodes.iter().map(ast_to_value).collect())
-        }
+        AstNode::Array(nodes) => serde_json::Value::Array(nodes.iter().map(ast_to_value).collect()),
         AstNode::Object(map) => serde_json::Value::Object(map.clone()),
         AstNode::Quote(inner) => ast_to_value(inner),
-        AstNode::Operator { operator, operands, metadata } => {
+        AstNode::Operator {
+            operator,
+            operands,
+            metadata,
+        } => {
             let mut arr = vec![serde_json::Value::String(operator.clone())];
             arr.extend(operands.iter().map(ast_to_value));
             if metadata.is_empty() {
@@ -702,7 +736,10 @@ fn ast_to_value(node: &AstNode) -> serde_json::Value {
             } else {
                 // Merge with metadata
                 let mut obj = metadata.clone();
-                obj.insert(operator.clone(), serde_json::Value::Array(arr[1..].to_vec()));
+                obj.insert(
+                    operator.clone(),
+                    serde_json::Value::Array(arr[1..].to_vec()),
+                );
                 serde_json::Value::Object(obj)
             }
         }
@@ -723,11 +760,15 @@ mod tests {
     fn eq_operator() {
         let result = evaluate_operator(
             "$eq",
-            &[AstNode::Symbol("$name".to_string()), AstNode::Literal(json!("Alice"))],
+            &[
+                AstNode::Symbol("$name".to_string()),
+                AstNode::Literal(json!("Alice")),
+            ],
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert!(fragment.contains("="));
@@ -744,28 +785,37 @@ mod tests {
             &[
                 AstNode::Operator {
                     operator: "$eq".to_string(),
-                    operands: vec![AstNode::Symbol("$name".to_string()), AstNode::Literal(json!("test"))],
+                    operands: vec![
+                        AstNode::Symbol("$name".to_string()),
+                        AstNode::Literal(json!("test")),
+                    ],
                     metadata: serde_json::Map::new(),
                 },
                 AstNode::Operator {
                     operator: "$gt".to_string(),
-                    operands: vec![AstNode::Symbol("$age".to_string()), AstNode::Literal(json!(18))],
+                    operands: vec![
+                        AstNode::Symbol("$age".to_string()),
+                        AstNode::Literal(json!(18)),
+                    ],
                     metadata: serde_json::Map::new(),
                 },
             ],
             &serde_json::Map::new(),
             &kctx(),
-            &|node: &AstNode| {
-                match node {
-                    AstNode::Operator { operator, operands, .. } => {
-                        evaluate_operator(operator, operands, &serde_json::Map::new(), &kctx(), &|_| {
-                            Err(HypatiaError::Eval("no deeper nesting".to_string()))
-                        })
-                    }
-                    _ => Err(HypatiaError::Eval("expected operator".to_string())),
-                }
+            &|node: &AstNode| match node {
+                AstNode::Operator {
+                    operator, operands, ..
+                } => evaluate_operator(
+                    operator,
+                    operands,
+                    &serde_json::Map::new(),
+                    &kctx(),
+                    &|_| Err(HypatiaError::Eval("no deeper nesting".to_string())),
+                ),
+                _ => Err(HypatiaError::Eval("expected operator".to_string())),
             },
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert!(fragment.contains("AND"));
@@ -785,7 +835,8 @@ mod tests {
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::FtsQuery { query } => {
                 assert_eq!(query, "hello world");
@@ -803,11 +854,15 @@ mod tests {
         for field in ["$tags", "tags"] {
             let result = evaluate_operator(
                 "$contains",
-                &[AstNode::Symbol(field.to_string()), AstNode::Literal(json!("rust"))],
+                &[
+                    AstNode::Symbol(field.to_string()),
+                    AstNode::Literal(json!("rust")),
+                ],
                 &serde_json::Map::new(),
                 &kctx(),
                 &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-            ).unwrap();
+            )
+            .unwrap();
             match result {
                 OperatorResult::SqlCondition { fragment, params } => {
                     assert!(fragment.contains("json_index"), "field {field}");
@@ -822,11 +877,15 @@ mod tests {
     fn contains_operator_scalar_field() {
         let result = evaluate_operator(
             "$contains",
-            &[AstNode::Symbol("$data".to_string()), AstNode::Literal(json!("rust"))],
+            &[
+                AstNode::Symbol("$data".to_string()),
+                AstNode::Literal(json!("rust")),
+            ],
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert_eq!(fragment, "json_extract(content, ?) LIKE ?");
@@ -842,22 +901,28 @@ mod tests {
             "$not",
             &[AstNode::Operator {
                 operator: "$eq".to_string(),
-                operands: vec![AstNode::Symbol("$name".to_string()), AstNode::Literal(json!("test"))],
+                operands: vec![
+                    AstNode::Symbol("$name".to_string()),
+                    AstNode::Literal(json!("test")),
+                ],
                 metadata: serde_json::Map::new(),
             }],
             &serde_json::Map::new(),
             &kctx(),
-            &|node: &AstNode| {
-                match node {
-                    AstNode::Operator { operator, operands, .. } => {
-                        evaluate_operator(operator, operands, &serde_json::Map::new(), &kctx(), &|_| {
-                            Err(HypatiaError::Eval("no deeper".to_string()))
-                        })
-                    }
-                    _ => Err(HypatiaError::Eval("expected operator".to_string())),
-                }
+            &|node: &AstNode| match node {
+                AstNode::Operator {
+                    operator, operands, ..
+                } => evaluate_operator(
+                    operator,
+                    operands,
+                    &serde_json::Map::new(),
+                    &kctx(),
+                    &|_| Err(HypatiaError::Eval("no deeper".to_string())),
+                ),
+                _ => Err(HypatiaError::Eval("expected operator".to_string())),
             },
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, .. } => {
                 assert!(fragment.starts_with("NOT ("));
@@ -870,11 +935,15 @@ mod tests {
     fn like_operator() {
         let result = evaluate_operator(
             "$like",
-            &[AstNode::Symbol("$name".to_string()), AstNode::Literal(json!("rust%"))],
+            &[
+                AstNode::Symbol("$name".to_string()),
+                AstNode::Literal(json!("rust%")),
+            ],
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert!(fragment.contains("LIKE"));
@@ -888,11 +957,15 @@ mod tests {
     fn like_operator_json_field() {
         let result = evaluate_operator(
             "$like",
-            &[AstNode::Symbol("$data".to_string()), AstNode::Literal(json!("%language%"))],
+            &[
+                AstNode::Symbol("$data".to_string()),
+                AstNode::Literal(json!("%language%")),
+            ],
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert_eq!(fragment, "json_extract(content, ?) LIKE ?");
@@ -912,7 +985,8 @@ mod tests {
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert!(fragment.contains("EXISTS (SELECT 1 FROM docs d JOIN json_index j"));
@@ -936,7 +1010,8 @@ mod tests {
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert!(fragment.contains(" AND "));
@@ -996,9 +1071,9 @@ mod tests {
                 );
                 match result {
                     Err(HypatiaError::Validation(_)) => {}
-                    other => panic!(
-                        "{op} did not reject injected field name {payload:?}: {other:?}"
-                    ),
+                    other => {
+                        panic!("{op} did not reject injected field name {payload:?}: {other:?}")
+                    }
                 }
             }
         }
@@ -1007,8 +1082,17 @@ mod tests {
     #[test]
     fn legitimate_field_names_still_resolve() {
         for field in [
-            "data", "tags", "format", "meta.author", "a.b.c", "tags[0]",
-            "rows[0][1]", "with_underscore", "with-dash", "字段", "f1",
+            "data",
+            "tags",
+            "format",
+            "meta.author",
+            "a.b.c",
+            "tags[0]",
+            "rows[0][1]",
+            "with_underscore",
+            "with-dash",
+            "字段",
+            "f1",
         ] {
             resolve_field(&kctx(), field)
                 .unwrap_or_else(|e| panic!("field {field:?} rejected: {e}"));
@@ -1039,11 +1123,15 @@ mod tests {
     fn ordering_comparison_casts_and_still_binds_the_path() {
         let result = evaluate_operator(
             "$gt",
-            &[AstNode::Symbol("$age".to_string()), AstNode::Literal(json!(18))],
+            &[
+                AstNode::Symbol("$age".to_string()),
+                AstNode::Literal(json!(18)),
+            ],
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert_eq!(fragment, "CAST(json_extract(content, ?) AS REAL) > ?");
@@ -1085,7 +1173,8 @@ mod tests {
             &serde_json::Map::new(),
             &kctx(),
             &|_| Err(HypatiaError::Eval("should not recurse".to_string())),
-        ).unwrap();
+        )
+        .unwrap();
         match result {
             OperatorResult::SqlCondition { fragment, params } => {
                 assert_eq!(fragment, "1=1");

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -1,16 +1,28 @@
 use serde_json::{Map, Value};
 
-use crate::error::{HypatiaError, Result};
 use super::ast::AstNode;
+use crate::error::{HypatiaError, Result};
 
 /// Recognized Hypatia JSE operators.
 const OPERATORS: &[&str] = &[
-    "$knowledge", "$statement",
-    "$and", "$or", "$not",
-    "$search", "$similar", "$k-hop", "$not-summaried",
-    "$gte", "$lte", "$gt", "$lt",
-    "$eq", "$ne",
-    "$like", "$contains", "$content",
+    "$knowledge",
+    "$statement",
+    "$and",
+    "$or",
+    "$not",
+    "$search",
+    "$similar",
+    "$k-hop",
+    "$not-summaried",
+    "$gte",
+    "$lte",
+    "$gt",
+    "$lt",
+    "$eq",
+    "$ne",
+    "$like",
+    "$contains",
+    "$content",
     "$quote",
 ];
 
@@ -39,7 +51,10 @@ impl Parser {
                     return Ok(AstNode::Array(Vec::new()));
                 }
                 // Check if first element is an operator string
-                if let Some(Value::String(first)) = arr.first().filter(|v| matches!(v, Value::String(s) if s.starts_with('$'))) {
+                if let Some(Value::String(first)) = arr
+                    .first()
+                    .filter(|v| matches!(v, Value::String(s) if s.starts_with('$')))
+                {
                     let operator = first.clone();
                     if operator == "$quote" {
                         // Quote: parse inner but wrap in Quote node
@@ -63,7 +78,8 @@ impl Parser {
                     });
                 }
                 // Plain array: parse each element
-                let nodes: Vec<AstNode> = arr.iter().map(Self::parse).collect::<Result<Vec<_>>>()?;
+                let nodes: Vec<AstNode> =
+                    arr.iter().map(Self::parse).collect::<Result<Vec<_>>>()?;
                 Ok(AstNode::Array(nodes))
             }
             Value::Object(obj) => {
@@ -103,11 +119,10 @@ impl Parser {
                             metadata,
                         })
                     }
-                    _ => {
-                        Err(HypatiaError::Parse(
-                            format!("object has multiple $ keys: {:?}", dollar_keys),
-                        ))
-                    }
+                    _ => Err(HypatiaError::Parse(format!(
+                        "object has multiple $ keys: {:?}",
+                        dollar_keys
+                    ))),
                 }
             }
         }
@@ -147,7 +162,9 @@ mod tests {
     fn parse_operator_array_form() {
         let ast = Parser::parse(&json!(["$and", true, false])).unwrap();
         match ast {
-            AstNode::Operator { operator, operands, .. } => {
+            AstNode::Operator {
+                operator, operands, ..
+            } => {
                 assert_eq!(operator, "$and");
                 assert_eq!(operands.len(), 2);
             }
@@ -159,7 +176,9 @@ mod tests {
     fn parse_operator_object_form() {
         let ast = Parser::parse(&json!({"$eq": "value"})).unwrap();
         match ast {
-            AstNode::Operator { operator, operands, .. } => {
+            AstNode::Operator {
+                operator, operands, ..
+            } => {
                 assert_eq!(operator, "$eq");
                 assert_eq!(operands.len(), 1);
             }
@@ -171,7 +190,9 @@ mod tests {
     fn parse_operator_with_metadata() {
         let ast = Parser::parse(&json!({"$search": "query text", "catalog": "knowledge"})).unwrap();
         match ast {
-            AstNode::Operator { operator, metadata, .. } => {
+            AstNode::Operator {
+                operator, metadata, ..
+            } => {
                 assert_eq!(operator, "$search");
                 assert_eq!(metadata["catalog"], json!("knowledge"));
             }
@@ -199,9 +220,16 @@ mod tests {
 
     #[test]
     fn parse_nested_operators() {
-        let ast = Parser::parse(&json!(["$and", ["$eq", "name", "Alice"], ["$gt", "age", 18]])).unwrap();
+        let ast = Parser::parse(&json!([
+            "$and",
+            ["$eq", "name", "Alice"],
+            ["$gt", "age", 18]
+        ]))
+        .unwrap();
         match ast {
-            AstNode::Operator { operator, operands, .. } => {
+            AstNode::Operator {
+                operator, operands, ..
+            } => {
                 assert_eq!(operator, "$and");
                 assert_eq!(operands.len(), 2);
                 // Each operand should be an Operator node
@@ -216,7 +244,9 @@ mod tests {
     fn parse_knowledge_operator() {
         let ast = Parser::parse(&json!(["$knowledge", ["$eq", "name", "test"]])).unwrap();
         match ast {
-            AstNode::Operator { operator, operands, .. } => {
+            AstNode::Operator {
+                operator, operands, ..
+            } => {
                 assert_eq!(operator, "$knowledge");
                 assert_eq!(operands.len(), 1);
             }

--- a/src/engine/postgres.rs
+++ b/src/engine/postgres.rs
@@ -1,0 +1,1040 @@
+//! PostgreSQL JSE compiler. Bindings are allocated while walking the AST, never
+//! by rewriting SQLite SQL. Install schema_functions when creating a PG shelf.
+use super::ast::AstNode;
+use super::evaluator::{ast_to_value, extract_query_opts, query_opts_to_search_opts};
+use super::operators::validate_field_path;
+use crate::error::{HypatiaError, Result};
+use crate::model::{QueryResult, QueryTarget, StatementKey};
+use crate::storage::{Storage, json_index::scalar_token};
+use serde_json::{Map, Value};
+
+/// Quote an identifier, including embedded quotes. No search_path assumptions.
+pub fn quote_identifier(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+struct Compiler<'a> {
+    schema: String,
+    target: QueryTarget,
+    store: &'a dyn Storage,
+    params: Vec<Value>,
+}
+
+impl Compiler<'_> {
+    fn bind(&mut self, value: Value, ty: &str) -> String {
+        self.params.push(value);
+        format!("${}::{}", self.params.len(), ty)
+    }
+    fn text(&mut self, value: impl Into<String>) -> String {
+        self.bind(Value::String(value.into()), "text")
+    }
+    fn function(&self, name: &str) -> String {
+        format!("{}.{}", self.schema, name)
+    }
+    fn table(&self, target: QueryTarget) -> String {
+        format!("{}.{}", self.schema, quote_identifier(target.table_name()))
+    }
+    fn membership(&mut self, path: &str, token: &str) -> String {
+        let path = self.text(path);
+        let token = self.text(token);
+        format!("COALESCE((q.tokens -> {path}) ? {token}, FALSE)")
+    }
+    // Return JSONB for JSON paths, and typed columns for fixed identifiers.
+    fn field(&mut self, field: &str, content_only: bool) -> Result<(String, bool)> {
+        let field = field.trim_start_matches('$');
+        if !content_only
+            && matches!(
+                field,
+                "name"
+                    | "triple"
+                    | "head"
+                    | "relation"
+                    | "tail"
+                    | "created_at"
+                    | "tr_start"
+                    | "tr_end"
+            )
+        {
+            return Ok((format!("q.{field}"), false));
+        }
+        validate_field_path(field)?;
+        let (root, path) = if let Some(path) = field.strip_prefix("data.") {
+            ("q.payload", path)
+        } else if field.starts_with("data[") {
+            ("q.payload", &field[4..])
+        } else {
+            ("q.content", field)
+        };
+        // Bound path segments preserve indexes and Unicode without constructing
+        // a PostgreSQL array literal (or needing an array driver binding).
+        let segments: Vec<_> = path
+            .split(['.', '[', ']'])
+            .filter(|s| !s.is_empty())
+            .map(|s| self.text(s))
+            .collect();
+        Ok((
+            format!("({root} #> ARRAY[{}]::text[])", segments.join(", ")),
+            true,
+        ))
+    }
+    fn scalar_text(&self, json: &str) -> String {
+        // JSON1 extracts booleans as integers and null as SQL NULL.
+        format!(
+            "(CASE jsonb_typeof({json}) WHEN 'boolean' THEN CASE WHEN {json} = 'true'::jsonb THEN '1' ELSE '0' END WHEN 'object' THEN {}({json}) WHEN 'array' THEN {}({json}) ELSE {json} #>> '{{}}' END)",
+            self.function("jse_compact"),
+            self.function("jse_compact")
+        )
+    }
+    fn condition(&mut self, node: &AstNode) -> Result<String> {
+        let AstNode::Operator {
+            operator, operands, ..
+        } = node
+        else {
+            return Err(HypatiaError::Eval("expected SQL condition".into()));
+        };
+        let arity = |n| {
+            if operands.len() == n {
+                Ok(())
+            } else {
+                Err(HypatiaError::Eval(format!(
+                    "{operator} expects {n} arguments"
+                )))
+            }
+        };
+        match operator.as_str() {
+            "$knowledge" | "$statement" => {
+                if operands.len() == 1 {
+                    self.condition(&operands[0])
+                } else {
+                    Ok("TRUE".into())
+                }
+            }
+            "$and" | "$or" => {
+                let parts = operands
+                    .iter()
+                    .map(|n| self.condition(n))
+                    .collect::<Result<Vec<_>>>()?;
+                if parts.is_empty() {
+                    return Ok("TRUE".into());
+                }
+                Ok(format!(
+                    "({})",
+                    parts.join(if operator == "$and" { " AND " } else { " OR " })
+                ))
+            }
+            "$not" => {
+                arity(1)?;
+                Ok(format!("NOT ({})", self.condition(&operands[0])?))
+            }
+            "$eq" | "$ne" | "$gt" | "$lt" | "$gte" | "$lte" => {
+                if operands.len() == 1 {
+                    return self.condition(&operands[0]);
+                }
+                arity(2)?;
+                let field = symbol(&operands[0])?;
+                let value = ast_to_value(&operands[1]);
+                let (mut lhs, json) = self.field(&field, false)?;
+                let op = match operator.as_str() {
+                    "$eq" => "=",
+                    "$ne" => "!=",
+                    "$gt" => ">",
+                    "$lt" => "<",
+                    "$gte" => ">=",
+                    _ => "<=",
+                };
+                let ordering = json && !matches!(op, "=" | "!=");
+                let rhs = if ordering {
+                    lhs = format!(
+                        "{}({})",
+                        self.function("jse_numeric"),
+                        self.scalar_text(&lhs)
+                    );
+                    // REAL affinity converts well-formed numeric strings. Other
+                    // strings sort after every number under SQLite's type order.
+                    let numeric = value.as_f64().or_else(|| {
+                        value.as_str().and_then(|s| {
+                            let s = s.trim();
+                            if s.chars().all(|c| {
+                                c.is_ascii_digit() || matches!(c, '+' | '-' | '.' | 'e' | 'E')
+                            }) {
+                                s.parse::<f64>().ok()
+                            } else {
+                                None
+                            }
+                        })
+                    });
+                    if let Some(n) = numeric {
+                        if n.is_finite() {
+                            self.bind(serde_json::json!(n), "double precision")
+                        } else {
+                            let p = self
+                                .text(value.as_str().expect("only numeric strings may overflow"));
+                            format!("{}({p})", self.function("jse_numeric"))
+                        }
+                    } else if value.is_null() {
+                        self.bind(Value::Null, "double precision")
+                    } else if let Some(b) = value.as_bool() {
+                        self.bind(
+                            serde_json::json!(if b { 1.0 } else { 0.0 }),
+                            "double precision",
+                        )
+                    } else {
+                        return Ok(format!(
+                            "(CASE WHEN {lhs} IS NULL THEN NULL ELSE {} END)",
+                            matches!(op, "<" | "<=")
+                        ));
+                    }
+                } else if json {
+                    if value.is_null() {
+                        return Ok(format!("({lhs} = NULL::jsonb)"));
+                    }
+                    if value.is_number() || value.is_boolean() {
+                        // Preserve numeric/bool equality while refusing string
+                        // coercion: JSON1 has no column affinity for equality.
+                        let text = self.scalar_text(&lhs);
+                        // Equality must retain integer precision beyond 2^53.
+                        // Only a JSON number/bool enters the numeric cast.
+                        let p = self.text(if let Some(b) = value.as_bool() {
+                            if b { "1".into() } else { "0".into() }
+                        } else {
+                            value.to_string()
+                        });
+                        return Ok(format!(
+                            "(CASE WHEN {lhs} IS NULL OR {lhs} = 'null'::jsonb THEN NULL WHEN jsonb_typeof({lhs}) IN ('number', 'boolean') THEN ({text})::numeric {op} {p}::numeric ELSE {} END)",
+                            op == "!="
+                        ));
+                    } else {
+                        // A non-string JSON scalar never equals a text binding.
+                        let text = self.scalar_text(&lhs);
+                        let p = self.text(
+                            value
+                                .as_str()
+                                .map(str::to_owned)
+                                .unwrap_or_else(|| value.to_string()),
+                        );
+                        return Ok(format!(
+                            "(CASE WHEN {lhs} IS NULL OR {lhs} = 'null'::jsonb THEN NULL WHEN jsonb_typeof({lhs}) IN ('number', 'boolean') THEN {} ELSE {text} {op} {p} END)",
+                            op == "!="
+                        ));
+                    }
+                } else {
+                    // Real columns have TEXT affinity in SQLite. In particular,
+                    // a bound bool is stored as integer 0/1 before that affinity.
+                    let value = match value {
+                        Value::Null | Value::String(_) => value,
+                        Value::Bool(b) => Value::String(if b { "1" } else { "0" }.into()),
+                        other => Value::String(other.to_string()),
+                    };
+                    let p = self.bind(value, "text");
+                    if matches!(
+                        field.trim_start_matches('$'),
+                        "created_at" | "tr_start" | "tr_end"
+                    ) {
+                        format!("{p}::timestamp")
+                    } else {
+                        p
+                    }
+                };
+                Ok(format!("{lhs} {op} {rhs}"))
+            }
+            "$contains" | "$like" => {
+                arity(2)?;
+                let field = symbol(&operands[0])?;
+                let v = ast_to_value(&operands[1]);
+                let text = v
+                    .as_str()
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| v.to_string());
+                if operator == "$contains"
+                    && matches!(
+                        field.trim_start_matches('$'),
+                        "tags" | "scopes" | "figures" | "synonyms"
+                    )
+                {
+                    return Ok(self.membership(field.trim_start_matches('$'), &text));
+                }
+                let (lhs, json) = self.field(&field, operator == "$contains")?;
+                let lhs = if json {
+                    self.scalar_text(&lhs)
+                } else {
+                    format!("({lhs})::text")
+                };
+                let p = self.text(if operator == "$contains" {
+                    format!("%{text}%")
+                } else {
+                    text
+                });
+                // SQLite LIKE folds ASCII only; PostgreSQL ILIKE folds according
+                // to locale. Disable PG's default backslash escape as well.
+                Ok(format!(
+                    "translate({lhs}, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') LIKE translate({p}, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') ESCAPE ''"
+                ))
+            }
+            "$has" => {
+                arity(2)?;
+                let field = symbol(&operands[0])?;
+                let v = ast_to_value(&operands[1]);
+                let values = if let Value::Array(a) = v { a } else { vec![v] };
+                let mut parts = Vec::new();
+                for v in values {
+                    let token = scalar_token(&v).ok_or_else(|| {
+                        HypatiaError::Eval("$has value must be a scalar or array of scalars".into())
+                    })?;
+                    parts.push(self.membership(&field, &token));
+                }
+                Ok(if parts.is_empty() {
+                    "FALSE".into()
+                } else {
+                    format!("({})", parts.join(" OR "))
+                })
+            }
+            "$content" => {
+                arity(1)?;
+                let AstNode::Object(map) = &operands[0] else {
+                    return Err(HypatiaError::Eval("$content expects a JSON object".into()));
+                };
+                let parts: Vec<_> = map
+                    .iter()
+                    .map(|(k, v)| {
+                        self.membership(k, &scalar_token(v).unwrap_or_else(|| v.to_string()))
+                    })
+                    .collect();
+                Ok(if parts.is_empty() {
+                    "TRUE".into()
+                } else {
+                    format!("({})", parts.join(" AND "))
+                })
+            }
+            "$json-contains" => {
+                arity(1)?;
+                let p = self.text(ast_to_value(&operands[0]).to_string());
+                // @> provides a GIN-eligible necessary condition. The recursive
+                // recheck disallows PG's array-contains-scalar special case.
+                Ok(format!(
+                    "(q.content @> {p}::jsonb AND {}(q.content, {p}::jsonb))",
+                    self.function("jse_json_contains")
+                ))
+            }
+            "$triple" => {
+                arity(3)?;
+                let parts = operands.iter().map(symbol).collect::<Result<Vec<_>>>()?;
+                if parts.iter().all(|s| s == "$*") {
+                    return Err(HypatiaError::Eval(
+                        "$triple requires at least one non-wildcard argument".into(),
+                    ));
+                }
+                if parts.iter().all(|s| s != "$*") {
+                    let key = StatementKey::new(&parts[0], &parts[1], &parts[2]);
+                    return Ok(format!("q.triple = {}", self.text(key.to_csv_key())));
+                }
+                let mut conditions = Vec::new();
+                for (col, v) in ["head", "relation", "tail"].iter().zip(parts) {
+                    if v != "$*" {
+                        conditions.push(format!("q.{col} = {}", self.text(v)));
+                    }
+                }
+                Ok(format!("({})", conditions.join(" AND ")))
+            }
+            _ => Err(HypatiaError::Eval(format!(
+                "{operator} is not a SQL condition"
+            ))),
+        }
+    }
+    fn operand(
+        &mut self,
+        node: &AstNode,
+        metadata: &Map<String, Value>,
+        not_summaried: bool,
+    ) -> Result<Option<String>> {
+        let AstNode::Operator {
+            operator, operands, ..
+        } = node
+        else {
+            return match node {
+                AstNode::Quote(_) | AstNode::Literal(_) => Ok(None),
+                _ => Err(HypatiaError::Eval(
+                    "unexpected node in condition context".into(),
+                )),
+            };
+        };
+        let opts = query_opts_to_search_opts(&extract_query_opts(metadata), self.target);
+        let (result, key) = match operator.as_str() {
+            "$search" | "$similar" => {
+                let n = operands.first().ok_or_else(|| {
+                    HypatiaError::Eval(format!("{operator} expects a query argument"))
+                })?;
+                let v = ast_to_value(n);
+                let text = v
+                    .as_str()
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| v.to_string());
+                if operator == "$search" {
+                    (self.store.execute_search(&text, &opts)?, "key")
+                } else {
+                    (
+                        self.store.execute_similar(&text, &opts, self.target)?,
+                        self.target.key_column(),
+                    )
+                }
+            }
+            "$k-hop" => {
+                if not_summaried || self.target != QueryTarget::Statement {
+                    return Err(HypatiaError::Eval(
+                        "$k-hop is only valid inside $statement".into(),
+                    ));
+                }
+                let ctx = super::operators::OpContext::for_target(self.target);
+                let r = super::operators::evaluate_operator(
+                    operator,
+                    operands,
+                    metadata,
+                    &ctx,
+                    &|_| Err(HypatiaError::Eval("unexpected condition".into())),
+                )?;
+                let super::operators::OperatorResult::KHop {
+                    subject,
+                    predicate,
+                    depth,
+                } = r
+                else {
+                    unreachable!()
+                };
+                (
+                    self.store
+                        .execute_khop(&subject, predicate.as_deref(), depth)?,
+                    "triple",
+                )
+            }
+            _ => return self.condition(node).map(Some),
+        };
+        let mut keys = Vec::new();
+        for row in result.rows {
+            if let Some(k) = row.get(key).and_then(Value::as_str) {
+                keys.push(self.text(k));
+            }
+        }
+        Ok(Some(if keys.is_empty() {
+            "FALSE".into()
+        } else {
+            format!("q.{} IN ({})", self.target.key_column(), keys.join(", "))
+        }))
+    }
+}
+
+fn symbol(node: &AstNode) -> Result<String> {
+    match node {
+        AstNode::Symbol(s) | AstNode::Literal(Value::String(s)) => Ok(s.clone()),
+        _ => Err(HypatiaError::Eval("expected symbol or string".into())),
+    }
+}
+
+pub(super) fn execute(ast: &AstNode, store: &dyn Storage) -> Result<QueryResult> {
+    let AstNode::Operator {
+        operator,
+        operands,
+        metadata,
+    } = ast
+    else {
+        return Err(HypatiaError::Eval(
+            "top-level expression must be a query operator".into(),
+        ));
+    };
+    let target = match operator.as_str() {
+        "$knowledge" | "$not-summaried" => QueryTarget::Knowledge,
+        "$statement" => QueryTarget::Statement,
+        _ => {
+            return Err(HypatiaError::Eval(format!(
+                "invalid top-level operator {operator}"
+            )));
+        }
+    };
+    let schema = store
+        .sql_schema()
+        .filter(|s| !s.is_empty() && !s.contains('\0'))
+        .ok_or_else(|| {
+            HypatiaError::Config("PostgreSQL storage requires an explicit SQL schema".into())
+        })?;
+    let mut c = Compiler {
+        schema: quote_identifier(schema),
+        target,
+        store,
+        params: Vec::new(),
+    };
+    let mut conditions = Vec::new();
+    let not_summaried = operator == "$not-summaried";
+    let rest = if not_summaried {
+        let tag = operands
+            .first()
+            .ok_or_else(|| HypatiaError::Eval("$not-summaried expects a tag argument".into()))?;
+        conditions.push(c.membership("tags", &symbol(tag)?));
+        conditions.push(format!(
+            "NOT EXISTS (SELECT 1 FROM {} AS s WHERE s.tail = q.name AND s.relation = 'summary')",
+            c.table(QueryTarget::Statement)
+        ));
+        &operands[1..]
+    } else {
+        operands.as_slice()
+    };
+    for n in rest {
+        if let Some(condition) = c.operand(n, metadata, not_summaried)? {
+            conditions.push(condition);
+        }
+    }
+    let select = match target {
+        QueryTarget::Knowledge => "q.name, q.content, q.created_at",
+        QueryTarget::Statement => {
+            "q.triple, q.head, q.relation, q.tail, q.content, q.created_at, q.tr_start, q.tr_end"
+        }
+    };
+    let mut sql = format!("SELECT {select} FROM {} AS q", c.table(target));
+    if !conditions.is_empty() {
+        sql.push_str(&format!(" WHERE {}", conditions.join(" AND ")));
+    }
+    sql.push_str(if not_summaried {
+        " ORDER BY q.created_at ASC"
+    } else {
+        " ORDER BY q.created_at DESC"
+    });
+    let opts = extract_query_opts(metadata);
+    let limit = c.bind(Value::from(opts.limit), "bigint");
+    let offset = c.bind(Value::from(opts.offset), "bigint");
+    // SQLite LIMIT -1 means unlimited, and negative OFFSET means zero.
+    sql.push_str(&format!(
+        " LIMIT CASE WHEN {limit} < 0 THEN NULL ELSE {limit} END OFFSET GREATEST({offset}, 0)"
+    ));
+    store.execute_query(target, &sql, c.params)
+}
+
+/// Canonical membership tokens derived before JSONB normalizes numeric text.
+/// Store this value in each row's tokens JSONB column, in the same transaction
+/// as content and payload. The existing postings walk defines path depth,
+/// opaque containers, null tokens, data parsing, and numeric spelling.
+pub fn membership_tokens(content_json: &str) -> Value {
+    let mut paths = Map::new();
+    for posting in crate::storage::json_index::content_postings(content_json) {
+        if let Some(token) = posting.value {
+            let values = paths
+                .entry(posting.path)
+                .or_insert_with(|| Value::Array(Vec::new()));
+            let values = values.as_array_mut().expect("token map contains arrays");
+            let value = Value::String(token);
+            if !values.contains(&value) {
+                values.push(value);
+            }
+        }
+    }
+    Value::Object(paths)
+}
+
+/// Shelf-local compatibility helpers. All are immutable and use only their
+/// arguments; content/payload stay JSONB and may retain native GIN indexes.
+/// The store owns applying this DDL transactionally with its schema migration.
+pub fn schema_functions(schema: &str) -> String {
+    let s = quote_identifier(schema);
+    // A schema name is data even inside a dollar-quoted SQL function body.
+    let mut tag = "$jse$".to_string();
+    while schema.contains(&tag) {
+        tag.insert(1, 'x');
+    }
+    format!(
+        r#"
+CREATE OR REPLACE FUNCTION {s}.jse_compact(v jsonb) RETURNS text
+LANGUAGE plpgsql IMMUTABLE STRICT AS {tag}
+DECLARE result text;
+BEGIN
+  CASE jsonb_typeof(v)
+    WHEN 'object' THEN
+      SELECT '{{' || COALESCE(string_agg(to_jsonb(key)::text || ':' || {s}.jse_compact(value), ',' ORDER BY key COLLATE "C"), '') || '}}'
+      INTO result FROM jsonb_each(v);
+    WHEN 'array' THEN
+      SELECT '[' || COALESCE(string_agg({s}.jse_compact(value), ',' ORDER BY ord), '') || ']'
+      INTO result FROM jsonb_array_elements(v) WITH ORDINALITY AS a(value, ord);
+    ELSE result := v::text;
+  END CASE;
+  RETURN result;
+END {tag};
+
+CREATE OR REPLACE FUNCTION {s}.jse_numeric(v text) RETURNS double precision
+LANGUAGE plpgsql IMMUTABLE STRICT AS {tag}
+DECLARE prefix text;
+BEGIN
+  prefix := substring(v FROM '^[[:space:]]*([+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?)');
+  IF prefix IS NULL THEN RETURN 0; END IF;
+  BEGIN
+    RETURN prefix::double precision;
+  EXCEPTION WHEN numeric_value_out_of_range THEN
+    -- SQLite REAL conversion saturates overflow and underflows to zero.
+    BEGIN
+      IF abs(prefix::numeric) < 1 THEN RETURN 0; END IF;
+    EXCEPTION WHEN numeric_value_out_of_range THEN
+      IF prefix ~ '[eE]-[0-9]+$' THEN RETURN 0; END IF;
+    END;
+    IF ltrim(prefix) LIKE '-%' THEN RETURN '-Infinity'::double precision; END IF;
+    RETURN 'Infinity'::double precision;
+  END;
+END {tag};
+
+CREATE OR REPLACE FUNCTION {s}.jse_json_contains(lhs jsonb, rhs jsonb) RETURNS boolean
+LANGUAGE plpgsql IMMUTABLE AS {tag}
+DECLARE item record;
+BEGIN
+  IF lhs IS NULL OR rhs IS NULL THEN RETURN false; END IF;
+  IF jsonb_typeof(lhs) <> jsonb_typeof(rhs) THEN RETURN false; END IF;
+  IF jsonb_typeof(rhs) = 'object' THEN
+    FOR item IN SELECT key, value FROM jsonb_each(rhs) LOOP
+      IF NOT {s}.jse_json_contains(lhs -> item.key, item.value) THEN RETURN false; END IF;
+    END LOOP;
+    RETURN true;
+  ELSIF jsonb_typeof(rhs) = 'array' THEN
+    FOR item IN SELECT value FROM jsonb_array_elements(rhs) LOOP
+      IF NOT EXISTS (SELECT 1 FROM jsonb_array_elements(lhs) AS a(value)
+                     WHERE {s}.jse_json_contains(a.value, item.value)) THEN RETURN false; END IF;
+    END LOOP;
+    RETURN true;
+  END IF;
+  RETURN lhs = rhs;
+END {tag};
+
+"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::Evaluator;
+    use crate::model::SearchOpts;
+    use serde_json::json;
+    use std::cell::RefCell;
+
+    #[derive(Default)]
+    struct RecordingStore {
+        query: RefCell<(String, Vec<Value>)>,
+        candidates: Vec<Map<String, Value>>,
+        schema: Option<String>,
+    }
+    impl Storage for RecordingStore {
+        fn sql_dialect(&self) -> super::super::SqlDialect {
+            super::super::SqlDialect::Postgres
+        }
+        fn sql_schema(&self) -> Option<&str> {
+            Some(self.schema.as_deref().unwrap_or("shelf\"quoted"))
+        }
+        fn execute_query(
+            &self,
+            _: QueryTarget,
+            sql: &str,
+            params: Vec<Value>,
+        ) -> Result<QueryResult> {
+            *self.query.borrow_mut() = (sql.into(), params);
+            Ok(QueryResult::new(vec![]))
+        }
+        fn execute_search(&self, _: &str, _: &SearchOpts) -> Result<QueryResult> {
+            Ok(QueryResult::new(self.candidates.clone()))
+        }
+        fn execute_similar(&self, _: &str, _: &SearchOpts, _: QueryTarget) -> Result<QueryResult> {
+            Ok(QueryResult::new(self.candidates.clone()))
+        }
+        fn execute_khop(&self, _: &str, _: Option<&str>, _: i64) -> Result<QueryResult> {
+            Ok(QueryResult::new(self.candidates.clone()))
+        }
+    }
+
+    #[test]
+    fn nested_bindings_payload_paths_and_injection_are_separate() {
+        let store = RecordingStore::default();
+        let poison = "x' OR TRUE -- ? $1";
+        Evaluator::execute(
+            &json!([
+                "$knowledge",
+                [
+                    "$and",
+                    ["$eq", "name", poison],
+                    [
+                        "$or",
+                        ["$gt", "data.score", 2],
+                        ["$has", "tags", [true, null, "a"]]
+                    ]
+                ]
+            ]),
+            &store,
+        )
+        .unwrap();
+        let q = store.query.borrow();
+        assert!(q.0.contains("FROM \"shelf\"\"quoted\".\"knowledge\" AS q"));
+        assert!(q.0.contains("q.payload #> ARRAY[$2::text]::text[]"));
+        assert!(q.0.contains("jse_numeric("));
+        assert!(!q.0.contains(poison));
+        assert_eq!(
+            q.1,
+            vec![
+                json!(poison),
+                json!("score"),
+                json!(2.0),
+                json!("tags"),
+                json!("true"),
+                json!("tags"),
+                json!(""),
+                json!("tags"),
+                json!("a"),
+                json!(100),
+                json!(0)
+            ]
+        );
+        assert!(q.0.contains("$10::bigint"));
+        assert!(q.0.contains("$11::bigint"));
+        assert!(!q.0.contains("json_extract"));
+    }
+
+    #[test]
+    fn candidate_keys_use_each_operator_contract_and_statement_pk() {
+        let row = json!({"key":"fts", "triple":"graph", "name":"vector"})
+            .as_object()
+            .unwrap()
+            .clone();
+        let store = RecordingStore {
+            candidates: vec![row],
+            ..Default::default()
+        };
+        Evaluator::execute(
+            &json!([
+                "$statement",
+                ["$search", "x"],
+                ["$similar", "x"],
+                ["$k-hop", "a", "r", 2]
+            ]),
+            &store,
+        )
+        .unwrap();
+        let q = store.query.borrow();
+        assert_eq!(&q.1[..3], &[json!("fts"), json!("graph"), json!("graph")]);
+        assert!(q.0.contains("q.triple IN ($1::text)"));
+        assert!(q.0.contains("q.triple IN ($2::text)"));
+        assert!(q.0.contains("q.triple IN ($3::text)"));
+        assert!(q.0.contains("ORDER BY q.created_at DESC"));
+        drop(q);
+        Evaluator::execute(&json!(["$knowledge", ["$similar", "x"]]), &store).unwrap();
+        assert_eq!(store.query.borrow().1[0], json!("vector"));
+    }
+
+    #[test]
+    fn not_summaried_qualifies_both_tables_and_keeps_binding_order() {
+        let store = RecordingStore::default();
+        Evaluator::execute(
+            &json!([
+                "$not-summaried",
+                "message",
+                ["$eq", "format", "text"],
+                ["$has", "tags", "rust"]
+            ]),
+            &store,
+        )
+        .unwrap();
+        let q = store.query.borrow();
+        assert!(q.0.contains("NOT EXISTS (SELECT 1 FROM \"shelf\"\"quoted\".\"statement\" AS s"));
+        assert!(q.0.contains("s.tail = q.name AND s.relation = 'summary'"));
+        assert!(q.0.contains("ORDER BY q.created_at ASC"));
+        assert_eq!(
+            q.1,
+            vec![
+                json!("tags"),
+                json!("message"),
+                json!("format"),
+                json!("text"),
+                json!("tags"),
+                json!("rust"),
+                json!(100),
+                json!(0)
+            ]
+        );
+    }
+
+    #[test]
+    fn exact_integer_equality_and_candidate_pagination() {
+        let store = RecordingStore::default();
+        Evaluator::execute(&json!({"$statement":[["$triple","a,b","r","c"],["$gte","tr_start","2025-01-01"],["$eq","data.id",9007199254740993u64],["$search","none"]],"limit":-1,"offset":-2}),&store).unwrap();
+        let q = store.query.borrow();
+        assert_eq!(
+            q.1,
+            vec![
+                json!("\"a,b\",r,c"),
+                json!("2025-01-01"),
+                json!("id"),
+                json!("9007199254740993"),
+                json!(-1),
+                json!(-2)
+            ]
+        );
+        assert!(q.0.contains("q.tr_start >= $2::text::timestamp"));
+        assert!(q.0.contains("$4::text::numeric"));
+        assert!(q.0.contains("AND FALSE"));
+        assert!(q.0.contains("LIMIT CASE WHEN $5::bigint < 0 THEN NULL ELSE $5::bigint END OFFSET GREATEST($6::bigint, 0)"));
+    }
+
+    #[test]
+    fn containment_is_native_prefilter_plus_strict_recheck() {
+        let store = RecordingStore::default();
+        Evaluator::execute(
+            &json!(["$knowledge", ["$json-contains", {"tags":"rust"}], ["$has", "tags", []]]),
+            &store,
+        )
+        .unwrap();
+        let q = store.query.borrow();
+        assert!(q.0.contains("q.content @> $1::text::jsonb"));
+        assert!(q.0.contains("jse_json_contains(q.content, $1::text::jsonb)"));
+        assert!(q.0.contains("AND FALSE"));
+        assert_eq!(q.1[0], json!(r#"{"tags":"rust"}"#));
+    }
+
+    #[test]
+    fn path_validation_and_like_escape_contract() {
+        let store = RecordingStore::default();
+        assert!(
+            Evaluator::execute(
+                &json!([
+                    "$knowledge",
+                    ["$eq", "data.x');DROP TABLE knowledge;--", "x"]
+                ]),
+                &store
+            )
+            .is_err()
+        );
+        Evaluator::execute(&json!(["$knowledge", ["$like", "data", "A\\_%"]]), &store).unwrap();
+        let q = store.query.borrow();
+        assert!(q.0.contains("translate("));
+        assert!(q.0.contains("ESCAPE ''"));
+        assert_eq!(q.1[1], json!("A\\_%"));
+    }
+
+    #[test]
+    fn membership_preserves_canonical_scientific_tokens_and_opaque_values() {
+        let content = json!({"tags":[1e-7,true,null,""], "data":r#"{"small":1e-7,"decimal":1.0,"opaque":{"v":1e-7}}"#});
+        let tokens = membership_tokens(&content.to_string());
+        assert_eq!(tokens["tags"], json!(["1e-7", "true", ""]));
+        assert_eq!(tokens["data.small"], json!(["1e-7"]));
+        assert_eq!(tokens["data.decimal"], json!(["1.0"]));
+        assert_eq!(tokens["data.opaque"], json!([r#"{"v":1e-7}"#]));
+        assert!(tokens.get("data").is_none());
+        let store = RecordingStore::default();
+        Evaluator::execute(
+            &json!([
+                "$knowledge",
+                ["$has", "data.small", 1e-7],
+                ["$not", ["$has", "missing", ""]]
+            ]),
+            &store,
+        )
+        .unwrap();
+        let q = store.query.borrow();
+        assert!(q.0.contains("COALESCE((q.tokens -> $1::text) ? $2::text, FALSE)"));
+        assert!(q.0.contains("NOT ((COALESCE((q.tokens -> $3::text) ? $4::text, FALSE)))"));
+        assert_eq!(q.1[1], json!("1e-7"));
+    }
+
+    #[test]
+    fn schema_dollar_quoting_cannot_end_function_body() {
+        let ddl = schema_functions("s$jse$\"; DROP SCHEMA public; --");
+        assert!(ddl.contains("AS $xjse$"));
+        assert!(ddl.contains("\"s$jse$\"\"; DROP SCHEMA public; --\".jse_compact"));
+    }
+
+    /// Run against an explicitly configured disposable PostgreSQL database.
+    /// Every DDL/data change is rolled back, including the unique shelf schema.
+    #[cfg(feature = "postgres-backend")]
+    #[test]
+    fn postgres_helpers_match_sqlite_numeric_tokens_and_containment() {
+        let Ok(url) = std::env::var("HYPATIA_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let mut client = postgres::Client::connect(&url, postgres::NoTls).unwrap();
+        let mut tx = client.transaction().unwrap();
+        let schema = format!("jse_test_{}", std::process::id());
+        let s = quote_identifier(&schema);
+        tx.batch_execute(&format!("CREATE SCHEMA {s}; {}", schema_functions(&schema)))
+            .unwrap();
+        let sqlite = rusqlite::Connection::open_in_memory().unwrap();
+        for text in [
+            "garbage",
+            "12.5tail",
+            "  -2e3ignored",
+            ".25",
+            "1e",
+            "true",
+            "1e400",
+            "1e-400",
+            "NaN",
+            "",
+        ] {
+            let expected: f64 = sqlite
+                .query_row("SELECT CAST(? AS REAL)", [text], |r| r.get(0))
+                .unwrap();
+            let actual: f64 = tx
+                .query_one(&format!("SELECT {s}.jse_numeric($1)"), &[&text])
+                .unwrap()
+                .get(0);
+            assert_eq!(actual, expected, "numeric {text:?}");
+        }
+        let null: Option<f64> = tx
+            .query_one(&format!("SELECT {s}.jse_numeric(NULL)"), &[])
+            .unwrap()
+            .get(0);
+        assert_eq!(null, None);
+        let content = json!({"tags":["rust", 1, true, null], "data":r#"{"score":3,"flags":[true,null],"nested":{"a":1}}"#, "synonyms":{"head":["x"]}});
+        let tokens = membership_tokens(&content.to_string());
+        let postings = crate::storage::json_index::content_postings(&content.to_string());
+        for (path, token) in [
+            ("tags", "rust"),
+            ("tags", "1"),
+            ("tags", "true"),
+            ("tags", ""),
+            ("tags", "false"),
+            ("data.score", "3"),
+            ("data.flags", "true"),
+            ("data.flags", ""),
+            ("data.nested", r#"{"a":1}"#),
+            ("synonyms.head", "x"),
+            ("data", content["data"].as_str().unwrap()),
+        ] {
+            let expected = postings
+                .iter()
+                .any(|p| p.path == path && p.value.as_deref() == Some(token));
+            let actual: bool = tx
+                .query_one(
+                    "SELECT COALESCE(($1::jsonb -> $2::text) ? $3::text, FALSE)",
+                    &[&tokens, &path, &token],
+                )
+                .unwrap()
+                .get(0);
+            assert_eq!(actual, expected, "membership {path} {token}");
+        }
+        for (lhs, rhs) in [
+            (json!([1]), json!(1)),
+            (json!({"x":[1]}), json!({"x":1})),
+            (json!([[1]]), json!([1])),
+            (json!([1, 2]), json!([2])),
+            (json!({"x":null}), json!({"x":null})),
+            (json!({}), json!({"x":null})),
+            (json!(true), json!(1)),
+        ] {
+            let expected = crate::storage::json_contains(&lhs, &rhs);
+            let actual: bool = tx
+                .query_one(
+                    &format!("SELECT {s}.jse_json_contains($1,$2)"),
+                    &[&lhs, &rhs],
+                )
+                .unwrap()
+                .get(0);
+            assert_eq!(actual, expected, "containment {lhs} {rhs}");
+        }
+        tx.batch_execute(&format!("CREATE TABLE {s}.knowledge(name text PRIMARY KEY, content jsonb, payload jsonb, tokens jsonb, created_at timestamp); CREATE TABLE {s}.statement(head text, relation text, tail text);")).unwrap();
+        for (name, score) in [
+            ("number", json!(3)),
+            ("numeric_text", json!("3")),
+            ("invalid", json!("oops")),
+            ("null", Value::Null),
+        ] {
+            let payload = json!({"n":4,"small":1e-7,"id":if name == "number" {9007199254740993u64} else {9007199254740992u64}});
+            let content =
+                json!({"score":score,"tags":["message",true,null],"data":payload.to_string()});
+            tx.execute(
+                &format!("INSERT INTO {s}.knowledge VALUES($1,$2,$3,$4,'2025-01-01'::timestamp)"),
+                &[
+                    &name,
+                    &content,
+                    &payload,
+                    &membership_tokens(&content.to_string()),
+                ],
+            )
+            .unwrap();
+        }
+        tx.batch_execute(&format!(
+            "INSERT INTO {s}.statement VALUES('summary','summary','number')"
+        ))
+        .unwrap();
+        let store = RecordingStore {
+            schema: Some(schema),
+            ..Default::default()
+        };
+        for (expr, mut expected) in [
+            (
+                json!(["$knowledge", ["$eq", "data.id", 9007199254740993u64]]),
+                vec!["number"],
+            ),
+            (
+                json!(["$knowledge", ["$eq", "score", "3"]]),
+                vec!["numeric_text"],
+            ),
+            (
+                json!(["$knowledge", ["$ne", "score", "3"]]),
+                vec!["invalid", "number"],
+            ),
+            (
+                json!(["$knowledge", ["$lt", "score", "NaN"]]),
+                vec!["invalid", "number", "numeric_text"],
+            ),
+            (
+                json!(["$knowledge", ["$lt", "score", "1e400"]]),
+                vec!["invalid", "number", "numeric_text"],
+            ),
+            (json!(["$knowledge", ["$ne", "missing", 3]]), vec![]),
+            (
+                json!(["$knowledge", ["$not", ["$has", "missing", ""]]]),
+                vec!["invalid", "null", "number", "numeric_text"],
+            ),
+            (
+                json!(["$knowledge", ["$has", "data.small", 1e-7]]),
+                vec!["invalid", "null", "number", "numeric_text"],
+            ),
+            (
+                json!(["$knowledge", ["$gt", "score", 2]]),
+                vec!["number", "numeric_text"],
+            ),
+            (json!(["$knowledge", ["$eq", "score", 3]]), vec!["number"]),
+            (
+                json!(["$knowledge", ["$ne", "score", 3]]),
+                vec!["invalid", "numeric_text"],
+            ),
+            (json!(["$knowledge", ["$lt", "score", 1]]), vec!["invalid"]),
+            (json!(["$knowledge", ["$eq", "score", null]]), vec![]),
+            (
+                json!(["$knowledge", ["$gt", "data.n", 3], ["$has", "tags", true]]),
+                vec!["invalid", "null", "number", "numeric_text"],
+            ),
+            (
+                json!(["$knowledge",["$json-contains",{"tags":"message"}]]),
+                vec![],
+            ),
+            (
+                json!(["$not-summaried", "message", ["$has", "tags", null]]),
+                vec!["invalid", "null", "numeric_text"],
+            ),
+        ] {
+            Evaluator::execute(&expr, &store).unwrap();
+            let q = store.query.borrow();
+            let prepared = tx.prepare(&q.0).unwrap();
+            let params: Vec<Box<dyn postgres::types::ToSql + Sync>> =
+                q.1.iter()
+                    .zip(prepared.params())
+                    .map(|(v, t)| -> Box<dyn postgres::types::ToSql + Sync> {
+                        match *t {
+                            postgres::types::Type::INT8 => Box::new(v.as_i64()),
+                            postgres::types::Type::FLOAT8 => Box::new(v.as_f64()),
+                            postgres::types::Type::TEXT => Box::new(v.as_str().map(str::to_owned)),
+                            _ => panic!("unexpected parameter type {t}"),
+                        }
+                    })
+                    .collect();
+            let refs: Vec<_> = params.iter().map(|p| &**p).collect();
+            let mut names: Vec<String> = tx
+                .query(&prepared, &refs)
+                .unwrap()
+                .iter()
+                .map(|r| r.get(0))
+                .collect();
+            names.sort();
+            expected.sort();
+            assert_eq!(names, expected, "compiled query {expr}");
+        }
+        tx.rollback().unwrap();
+    }
+}

--- a/src/engine/sql_builder.rs
+++ b/src/engine/sql_builder.rs
@@ -1,5 +1,13 @@
 use crate::model::QueryTarget;
 
+/// SQL emitted for the selected storage backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SqlDialect {
+    #[default]
+    Sqlite,
+    Postgres,
+}
+
 /// Builds parameterized SQL queries from collected conditions (SQLite dialect).
 pub struct SqlBuilder {
     target: QueryTarget,
@@ -56,7 +64,8 @@ impl SqlBuilder {
 
         // Bound parameters are typed by the store (numbers -> INTEGER), so
         // plain LIMIT/OFFSET placeholders suffice.
-        self.params.push(serde_json::Value::Number(self.limit.into()));
+        self.params
+            .push(serde_json::Value::Number(self.limit.into()));
         self.params
             .push(serde_json::Value::Number(self.offset.into()));
 
@@ -88,7 +97,9 @@ mod tests {
         builder.set_limit(10);
         builder.set_offset(20);
         let (sql, params) = builder.build();
-        assert!(sql.contains("SELECT triple, head, relation, tail, content, created_at, tr_start, tr_end"));
+        assert!(sql.contains(
+            "SELECT triple, head, relation, tail, content, created_at, tr_start, tr_end"
+        ));
         assert!(sql.contains("FROM statement"));
         assert!(sql.contains("LIMIT ? OFFSET ?"));
         assert_eq!(params[0], serde_json::json!(10));

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,9 @@ pub enum HypatiaError {
     #[error("SQLite error: {}", redact_sql(.0))]
     Sqlite(#[from] rusqlite::Error),
 
+    #[cfg(feature = "postgres-backend")]
+    #[error("PostgreSQL error: {0}")]
+    Postgres(#[from] postgres::Error),
 
     #[error("JSE parse error: {0}")]
     Parse(String),
@@ -95,7 +98,10 @@ mod tests {
     #[test]
     fn storage_error_display_omits_sql() {
         let rendered = HypatiaError::from(StorageError::from(sql_input_error())).to_string();
-        assert_eq!(rendered, "storage error: SQLite error: near \"b\": syntax error");
+        assert_eq!(
+            rendered,
+            "storage error: SQLite error: near \"b\": syntax error"
+        );
         assert!(!rendered.contains("SELECT"));
         assert!(!rendered.contains("json_extract"));
     }

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -8,6 +8,7 @@ use crate::service::{KnowledgeService, StatementService};
 use crate::storage::{ShelfManager, Storage};
 
 /// Statistics returned by backfill operation.
+#[derive(Debug)]
 pub struct BackfillStats {
     pub created: usize,
     pub skipped: usize,
@@ -42,6 +43,10 @@ impl Lab {
         self.shelf_manager.export(name, dest)
     }
 
+    pub fn import_shelf(&mut self, name: &str, source: &Path, reembed: bool) -> Result<()> {
+        self.shelf_manager.import(name, source, reembed)
+    }
+
     // --- JSE Query ---
 
     pub fn query(&mut self, shelf_name: &str, jse: &serde_json::Value) -> Result<QueryResult> {
@@ -53,7 +58,12 @@ impl Lab {
 
     // --- Knowledge CRUD ---
 
-    pub fn create_knowledge(&mut self, shelf: &str, name: &str, content: Content) -> Result<Knowledge> {
+    pub fn create_knowledge(
+        &mut self,
+        shelf: &str,
+        name: &str,
+        content: Content,
+    ) -> Result<Knowledge> {
         let shelf_ref = self.shelf_manager.get_mut(shelf).ok_or_else(|| {
             crate::error::HypatiaError::Shelf(format!("shelf '{shelf}' is not connected"))
         })?;
@@ -65,10 +75,15 @@ impl Lab {
         let shelf_ref = self.shelf_manager.get(shelf).ok_or_else(|| {
             crate::error::HypatiaError::Shelf(format!("shelf '{shelf}' is not connected"))
         })?;
-        shelf_ref.store.get_knowledge(name)
+        shelf_ref.backend.get_knowledge(name)
     }
 
-    pub fn update_knowledge(&mut self, shelf: &str, name: &str, content: Content) -> Result<Knowledge> {
+    pub fn update_knowledge(
+        &mut self,
+        shelf: &str,
+        name: &str,
+        content: Content,
+    ) -> Result<Knowledge> {
         let shelf_ref = self.shelf_manager.get_mut(shelf).ok_or_else(|| {
             crate::error::HypatiaError::Shelf(format!("shelf '{shelf}' is not connected"))
         })?;
@@ -105,7 +120,7 @@ impl Lab {
         let shelf_ref = self.shelf_manager.get(shelf).ok_or_else(|| {
             crate::error::HypatiaError::Shelf(format!("shelf '{shelf}' is not connected"))
         })?;
-        shelf_ref.store.get_statement(key)
+        shelf_ref.backend.get_statement(key)
     }
 
     pub fn delete_statement(&mut self, shelf: &str, key: &StatementKey) -> Result<()> {
@@ -145,12 +160,8 @@ impl Lab {
         };
 
         match target {
-            "knowledge" => {
-                shelf_ref.execute_similar(query, &opts, QueryTarget::Knowledge)
-            }
-            "statement" => {
-                shelf_ref.execute_similar(query, &opts, QueryTarget::Statement)
-            }
+            "knowledge" => shelf_ref.execute_similar(query, &opts, QueryTarget::Knowledge),
+            "statement" => shelf_ref.execute_similar(query, &opts, QueryTarget::Statement),
             "both" => {
                 let mut knowledge_rows = shelf_ref
                     .execute_similar(query, &opts, QueryTarget::Knowledge)?
@@ -188,11 +199,9 @@ impl Lab {
                 all_rows.truncate(limit as usize);
                 Ok(QueryResult::new(all_rows))
             }
-            _ => Err(crate::error::HypatiaError::Validation(
-                format!(
-                    "invalid target '{target}': must be 'knowledge', 'statement', or 'both'"
-                ),
-            )),
+            _ => Err(crate::error::HypatiaError::Validation(format!(
+                "invalid target '{target}': must be 'knowledge', 'statement', or 'both'"
+            ))),
         }
     }
 
@@ -201,7 +210,12 @@ impl Lab {
     /// Store a file in the shelf's archives/ directory.
     /// `dest_relative` is the target path relative to archives/ (e.g., "euclid/fig1.png").
     /// Returns the absolute path of the stored file.
-    pub fn store_archive(&self, shelf: &str, src: &Path, dest_relative: &str) -> Result<std::path::PathBuf> {
+    pub fn store_archive(
+        &self,
+        shelf: &str,
+        src: &Path,
+        dest_relative: &str,
+    ) -> Result<std::path::PathBuf> {
         let archives_dir = self.shelf_manager.archives_path(shelf).ok_or_else(|| {
             crate::error::HypatiaError::Shelf(format!("shelf '{shelf}' is not connected"))
         })?;
@@ -239,6 +253,14 @@ impl Lab {
     /// Generate embedding vectors for all entries that don't have one yet.
     /// Idempotent: entries that already have vectors are skipped.
     pub fn backfill_vectors(&mut self, shelf: &str) -> Result<BackfillStats> {
+        self.backfill_vectors_with_reembed(shelf, false)
+    }
+
+    pub fn backfill_vectors_with_reembed(
+        &mut self,
+        shelf: &str,
+        reembed: bool,
+    ) -> Result<BackfillStats> {
         let shelf_ref = self.shelf_manager.get_mut(shelf).ok_or_else(|| {
             crate::error::HypatiaError::Shelf(format!("shelf '{shelf}' is not connected"))
         })?;
@@ -249,55 +271,163 @@ impl Lab {
             ));
         }
 
-        let mut stats = BackfillStats { created: 0, skipped: 0, errors: 0 };
-
-        // Backfill knowledge entries
-        let knowledge_missing = shelf_ref.store.knowledge_without_embeddings()?;
-        stats.skipped += shelf_ref.store.knowledge_with_embeddings()?.len();
-
-        for (name, content_json) in knowledge_missing {
-            let content = match Content::from_json_str(&content_json) {
-                Ok(c) => c,
-                Err(_) => { stats.errors += 1; continue; }
+        if !reembed
+            && !shelf_ref.backend.embeddings_identified()?
+            && shelf_ref.backend.embedding_row_count("knowledge")?
+                + shelf_ref.backend.embedding_row_count("statement")?
+                > 0
+        {
+            return Err(crate::error::HypatiaError::Config(
+                "legacy vector identity is unknown; run backfill --reembed explicitly".into(),
+            ));
+        }
+        if reembed {
+            if !shelf_ref.settings.embedding.model_identity_trusted {
+                return Err(crate::error::HypatiaError::Config(
+                    "re-embedding requires an identifiable configured model".into(),
+                ));
+            }
+            let metadata = crate::storage::transfer::EmbeddingMetadata {
+                model: shelf_ref.settings.embedding.model_identity().into(),
+                dimensions: shelf_ref.settings.embedding.dimensions(),
+                metric: "cosine".into(),
             };
+            shelf_ref.backend.reset_embeddings(&metadata)?;
+        }
+        let mut stats = BackfillStats {
+            created: 0,
+            skipped: 0,
+            errors: 0,
+        };
 
-            let text = content.embedding_text(&name);
-            match shelf_ref.embedder.embed(&text) {
-                Ok(vector) => {
-                    match shelf_ref.store.upsert_knowledge_embedding(&name, &vector) {
-                        Ok(_) => stats.created += 1,
-                        Err(_) => stats.errors += 1,
+        for catalog in ["knowledge", "statement"] {
+            stats.skipped += shelf_ref.backend.embedding_row_count(catalog)?;
+            let mut after: Option<String> = None;
+            loop {
+                let page = shelf_ref
+                    .backend
+                    .missing_embeddings(catalog, after.as_deref(), 128)?;
+                if page.is_empty() {
+                    break;
+                }
+                for (key, content, version) in page {
+                    after = Some(key.clone());
+                    match shelf_ref.embedder.embed(&content.embedding_text(&key)) {
+                        Ok(vector) => match shelf_ref
+                            .backend
+                            .install_embedding(catalog, &key, version, &vector)
+                        {
+                            Ok(true) => stats.created += 1,
+                            Ok(false) => stats.skipped += 1,
+                            Err(e) => {
+                                eprintln!("backfill {catalog}/{key}: {e}");
+                                stats.errors += 1;
+                            }
+                        },
+                        Err(e) => {
+                            eprintln!("backfill {catalog}/{key}: {e}");
+                            stats.errors += 1;
+                        }
                     }
                 }
-                Err(_) => stats.errors += 1,
             }
         }
-
-        // Backfill statement entries
-        let stmt_missing = shelf_ref.store.statements_without_embeddings()?;
-
-        for (triple, content_json) in stmt_missing {
-            let content = match Content::from_json_str(&content_json) {
-                Ok(c) => c,
-                Err(_) => { stats.errors += 1; continue; }
-            };
-
-            let text = content.embedding_text(&triple);
-            match shelf_ref.embedder.embed(&text) {
-                Ok(vector) => {
-                    match shelf_ref.store.upsert_statement_embedding(&triple, &vector) {
-                        Ok(_) => stats.created += 1,
-                        Err(_) => stats.errors += 1,
-                    }
-                }
-                Err(_) => stats.errors += 1,
-            }
-        }
-
-        // Rebuild ANN snapshots from the authoritative BLOBs and persist.
         shelf_ref.rebuild_vector_indexes()?;
 
         Ok(stats)
+    }
+}
+
+#[cfg(test)]
+mod backfill_tests {
+    use super::*;
+    use crate::embedding::EmbeddingProvider;
+    struct Fixed {
+        fail: bool,
+    }
+    impl EmbeddingProvider for Fixed {
+        fn embed(&self, _: &str) -> Result<Vec<f32>> {
+            if self.fail {
+                Err(crate::error::HypatiaError::Embedding(
+                    "test network failure".into(),
+                ))
+            } else {
+                Ok(vec![1., 0., 0.])
+            }
+        }
+        fn dimensions(&self) -> usize {
+            3
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+    }
+    #[test]
+    fn saved_content_survives_provider_failure_and_existing_backfill_repairs_it() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("shelf.toml"),
+            "[embedding]\nmodel='hypatia-contract-test'\ndimensions=3\n",
+        )
+        .unwrap();
+        let mut manager = ShelfManager::with_home(home.path().into()).unwrap();
+        manager.connect(dir.path(), Some("test")).unwrap();
+        manager.get_mut("test").unwrap().embedder = Box::new(Fixed { fail: true });
+        let mut lab = Lab {
+            shelf_manager: manager,
+        };
+        assert_eq!(
+            lab.create_knowledge("test", "key", Content::new("saved"))
+                .unwrap()
+                .content
+                .data,
+            "saved"
+        );
+        let key = StatementKey::new("a", "r", "b");
+        lab.create_statement("test", &key, Content::new("edge"), None, None)
+            .unwrap();
+        assert_eq!(lab.backfill_vectors("test").unwrap().errors, 2);
+        lab.shelf_manager.get_mut("test").unwrap().embedder = Box::new(Fixed { fail: false });
+        assert_eq!(lab.backfill_vectors("test").unwrap().created, 2);
+        assert_eq!(lab.backfill_vectors("test").unwrap().skipped, 2);
+        let legacy = crate::storage::SqliteStore::open(&dir.path().join("hypatia.sqlite")).unwrap();
+        legacy
+            .conn()
+            .execute("DELETE FROM meta WHERE k='embedding_metadata'", [])
+            .unwrap();
+        assert!(
+            lab.backfill_vectors("test")
+                .unwrap_err()
+                .to_string()
+                .contains("--reembed")
+        );
+        assert_eq!(
+            lab.backfill_vectors_with_reembed("test", true)
+                .unwrap()
+                .created,
+            2
+        );
+        lab.shelf_manager.get_mut("test").unwrap().embedder = Box::new(Fixed { fail: true });
+        lab.update_knowledge("test", "key", Content::new("new saved"))
+            .unwrap();
+        assert_eq!(
+            lab.get_knowledge("test", "key")
+                .unwrap()
+                .unwrap()
+                .content
+                .data,
+            "new saved"
+        );
+        assert_eq!(
+            lab.shelf_manager
+                .get("test")
+                .unwrap()
+                .backend
+                .embedding_row_count("knowledge")
+                .unwrap(),
+            0
+        );
     }
 }
 

--- a/src/model/content.rs
+++ b/src/model/content.rs
@@ -185,8 +185,7 @@ mod tests {
 
     #[test]
     fn figures_roundtrip() {
-        let c = Content::new("desc")
-            .with_figures(vec!["archive://euclid/fig1.png".to_string()]);
+        let c = Content::new("desc").with_figures(vec!["archive://euclid/fig1.png".to_string()]);
         let json = c.to_json_string();
         let c2 = Content::from_json_str(&json).unwrap();
         assert_eq!(c, c2);
@@ -232,7 +231,10 @@ mod tests {
     fn synonyms_positional_roundtrip() {
         let mut map = HashMap::new();
         map.insert("head".to_string(), vec!["Alice A.".to_string()]);
-        map.insert("relation".to_string(), vec!["leads".to_string(), "manages".to_string()]);
+        map.insert(
+            "relation".to_string(),
+            vec!["leads".to_string(), "manages".to_string()],
+        );
         let c = Content::new("data").with_synonyms(Some(Synonyms::Positional(map)));
         let json = c.to_json_string();
         let c2 = Content::from_json_str(&json).unwrap();
@@ -254,7 +256,10 @@ mod tests {
     #[test]
     fn fts_fields_positional_synonyms() {
         let mut map = HashMap::new();
-        map.insert("head".to_string(), vec!["Bob".to_string(), "Robert".to_string()]);
+        map.insert(
+            "head".to_string(),
+            vec!["Bob".to_string(), "Robert".to_string()],
+        );
         map.insert("tail".to_string(), vec!["DB".to_string()]);
         let c = Content::new("data").with_synonyms(Some(Synonyms::Positional(map)));
         let f = c.fts_fields("triple_key");

--- a/src/model/knowledge.rs
+++ b/src/model/knowledge.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDateTime;
 
 use super::Content;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Knowledge {
     pub name: String,
     pub content: Content,

--- a/src/model/shelf.rs
+++ b/src/model/shelf.rs
@@ -89,10 +89,19 @@ mod tests {
     #[test]
     fn shelf_config_paths() {
         let config = ShelfConfig::from_path(Path::new("/tmp/test-shelf"), None);
-        assert_eq!(config.sqlite_path, PathBuf::from("/tmp/test-shelf/hypatia.sqlite"));
-        assert_eq!(config.vectors_path, PathBuf::from("/tmp/test-shelf/vectors"));
+        assert_eq!(
+            config.sqlite_path,
+            PathBuf::from("/tmp/test-shelf/hypatia.sqlite")
+        );
+        assert_eq!(
+            config.vectors_path,
+            PathBuf::from("/tmp/test-shelf/vectors")
+        );
         assert_eq!(config.id.name, "test-shelf");
-        assert_eq!(config.archives_path, PathBuf::from("/tmp/test-shelf/archives"));
+        assert_eq!(
+            config.archives_path,
+            PathBuf::from("/tmp/test-shelf/archives")
+        );
     }
 
     #[test]

--- a/src/model/statement.rs
+++ b/src/model/statement.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDateTime;
 
 use super::Content;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StatementKey {
     pub head: String,
     pub relation: String,
@@ -10,7 +10,11 @@ pub struct StatementKey {
 }
 
 impl StatementKey {
-    pub fn new(head: impl Into<String>, relation: impl Into<String>, tail: impl Into<String>) -> Self {
+    pub fn new(
+        head: impl Into<String>,
+        relation: impl Into<String>,
+        tail: impl Into<String>,
+    ) -> Self {
         Self {
             head: head.into(),
             relation: relation.into(),
@@ -43,7 +47,7 @@ impl StatementKey {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Statement {
     pub key: StatementKey,
     pub content: Content,
@@ -77,8 +81,6 @@ pub fn csv_split(s: &str) -> Vec<String> {
                 } else {
                     in_quotes = false;
                 }
-            } else if ch == '"' {
-                in_quotes = true;
             } else {
                 current.push(ch);
             }
@@ -155,6 +157,9 @@ mod tests {
 
     #[test]
     fn csv_split_quoted() {
-        assert_eq!(csv_split("\"Alice, Jr.\",knows,Bob"), vec!["Alice, Jr.", "knows", "Bob"]);
+        assert_eq!(
+            csv_split("\"Alice, Jr.\",knows,Bob"),
+            vec!["Alice, Jr.", "knows", "Bob"]
+        );
     }
 }

--- a/src/service/knowledge.rs
+++ b/src/service/knowledge.rs
@@ -13,16 +13,13 @@ impl<'a> KnowledgeService<'a> {
 
     pub fn create(&mut self, name: &str, content: Content) -> Result<Knowledge> {
         // Source row + FTS doc are written in one store transaction.
-        self.shelf.store.insert_knowledge(name, &content)?;
+        let version = self.shelf.backend.insert_knowledge(name, &content)?;
 
         // Generate embedding and store the BLOB (best-effort: skip if model unavailable)
-        if let Some(vector) = self.shelf.embedder.maybe_embed(&content.embedding_text(name))? {
-            self.shelf.store.upsert_knowledge_embedding(name, &vector)?;
-            self.shelf.vector_upsert("knowledge", name, &vector)?;
-        }
+        self.shelf.embed_saved("knowledge", name, &content, version);
 
         // Read back to get the generated timestamp
-        let knowledge = self.shelf.store.get_knowledge(name)?.ok_or_else(|| {
+        let knowledge = self.shelf.backend.get_knowledge(name)?.ok_or_else(|| {
             crate::error::HypatiaError::NotFound {
                 kind: "knowledge".to_string(),
                 key: name.to_string(),
@@ -32,18 +29,15 @@ impl<'a> KnowledgeService<'a> {
     }
 
     pub fn get(&self, name: &str) -> Result<Option<Knowledge>> {
-        self.shelf.store.get_knowledge(name)
+        self.shelf.backend.get_knowledge(name)
     }
 
     pub fn update(&mut self, name: &str, content: Content) -> Result<Knowledge> {
-        self.shelf.store.update_knowledge(name, &content)?;
+        let version = self.shelf.backend.update_knowledge(name, &content)?;
 
-        if let Some(vector) = self.shelf.embedder.maybe_embed(&content.embedding_text(name))? {
-            self.shelf.store.upsert_knowledge_embedding(name, &vector)?;
-            self.shelf.vector_upsert("knowledge", name, &vector)?;
-        }
+        self.shelf.embed_saved("knowledge", name, &content, version);
 
-        let knowledge = self.shelf.store.get_knowledge(name)?.ok_or_else(|| {
+        let knowledge = self.shelf.backend.get_knowledge(name)?.ok_or_else(|| {
             crate::error::HypatiaError::NotFound {
                 kind: "knowledge".to_string(),
                 key: name.to_string(),
@@ -53,8 +47,6 @@ impl<'a> KnowledgeService<'a> {
     }
 
     pub fn delete(&mut self, name: &str) -> Result<()> {
-        // Drop the ANN vector BEFORE the doc row disappears (doc_id lookup).
-        self.shelf.vector_remove("knowledge", name)?;
-        self.shelf.store.delete_knowledge(name)
+        self.shelf.backend.delete_knowledge(name)
     }
 }

--- a/src/service/statement.rs
+++ b/src/service/statement.rs
@@ -22,15 +22,16 @@ impl<'a> StatementService<'a> {
     ) -> Result<Statement> {
         let csv_key = key.to_csv_key();
         // Source row + FTS doc are written in one store transaction.
-        self.shelf.store.insert_statement(key, &content, tr_start, tr_end)?;
+        let version = self
+            .shelf
+            .backend
+            .insert_statement(key, &content, tr_start, tr_end)?;
 
         // Generate embedding and store the BLOB (best-effort)
-        if let Some(vector) = self.shelf.embedder.maybe_embed(&content.embedding_text(&csv_key))? {
-            self.shelf.store.upsert_statement_embedding(&csv_key, &vector)?;
-            self.shelf.vector_upsert("statement", &csv_key, &vector)?;
-        }
+        self.shelf
+            .embed_saved("statement", &csv_key, &content, version);
 
-        let statement = self.shelf.store.get_statement(key)?.ok_or_else(|| {
+        let statement = self.shelf.backend.get_statement(key)?.ok_or_else(|| {
             crate::error::HypatiaError::NotFound {
                 kind: "statement".to_string(),
                 key: csv_key,
@@ -40,7 +41,7 @@ impl<'a> StatementService<'a> {
     }
 
     pub fn get(&self, key: &StatementKey) -> Result<Option<Statement>> {
-        self.shelf.store.get_statement(key)
+        self.shelf.backend.get_statement(key)
     }
 
     pub fn update(
@@ -51,14 +52,15 @@ impl<'a> StatementService<'a> {
         tr_end: Option<NaiveDateTime>,
     ) -> Result<Statement> {
         let csv_key = key.to_csv_key();
-        self.shelf.store.update_statement(key, &content, tr_start, tr_end)?;
+        let version = self
+            .shelf
+            .backend
+            .update_statement(key, &content, tr_start, tr_end)?;
 
-        if let Some(vector) = self.shelf.embedder.maybe_embed(&content.embedding_text(&csv_key))? {
-            self.shelf.store.upsert_statement_embedding(&csv_key, &vector)?;
-            self.shelf.vector_upsert("statement", &csv_key, &vector)?;
-        }
+        self.shelf
+            .embed_saved("statement", &csv_key, &content, version);
 
-        let statement = self.shelf.store.get_statement(key)?.ok_or_else(|| {
+        let statement = self.shelf.backend.get_statement(key)?.ok_or_else(|| {
             crate::error::HypatiaError::NotFound {
                 kind: "statement".to_string(),
                 key: csv_key,
@@ -68,8 +70,6 @@ impl<'a> StatementService<'a> {
     }
 
     pub fn delete(&mut self, key: &StatementKey) -> Result<()> {
-        // Drop the ANN vector BEFORE the doc row disappears (doc_id lookup).
-        self.shelf.vector_remove("statement", &key.to_csv_key())?;
-        self.shelf.store.delete_statement(key)
+        self.shelf.backend.delete_statement(key)
     }
 }

--- a/src/storage/backend.rs
+++ b/src/storage/backend.rs
@@ -1,0 +1,652 @@
+//! Complete shelf backend boundary. Local vector files never escape LocalBackend.
+use super::{
+    SqliteStore, VectorFileIndex, open_or_migrate,
+    settings::{BackendKind, ShelfSettings},
+    transfer::{EmbeddingMetadata, Snapshot, validate_vector},
+};
+use crate::{
+    error::{HypatiaError, Result},
+    model::{Content, Knowledge, QueryTarget, SearchOpts, ShelfConfig, Statement, StatementKey},
+};
+use chrono::NaiveDateTime;
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+pub struct ShelfBackend {
+    inner: Backend,
+    dims: usize,
+}
+enum Backend {
+    Local(LocalBackend),
+    #[cfg(feature = "postgres-backend")]
+    Postgres(super::postgres_store::PgStore),
+}
+struct LocalBackend {
+    store: SqliteStore,
+    vectors: std::cell::RefCell<HashMap<String, VectorFileIndex>>,
+    path: PathBuf,
+    dims: usize,
+    cache_clock: std::cell::Cell<i64>,
+    cache_identity: String,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CacheManifest {
+    identity: String,
+    clock: i64,
+    dimensions: usize,
+    catalogs: Vec<String>,
+}
+impl LocalBackend {
+    fn clock(&self) -> Result<i64> {
+        Ok(self.store.conn().query_row(
+            "SELECT CAST(v AS INTEGER) FROM meta WHERE k='content_clock'",
+            [],
+            |r| r.get(0),
+        )?)
+    }
+    fn cache_file(&self, clock: i64, catalog: &str) -> PathBuf {
+        self.path.join(format!(
+            "{}-{clock}-{}-{catalog}.usearch",
+            self.cache_identity, self.dims
+        ))
+    }
+    // Caller holds a DB read transaction; clock, vectors, and later hydrated
+    // content all describe the same database snapshot.
+    fn refresh_snapshot(&self, clock: i64, force: bool) -> Result<()> {
+        if !force && self.cache_clock.get() == clock {
+            return Ok(());
+        }
+        if !force {
+            if let Ok(bytes) = std::fs::read(self.path.join("cache.json")) {
+                if let Ok(manifest) = serde_json::from_slice::<CacheManifest>(&bytes) {
+                    if manifest.identity == self.cache_identity
+                        && manifest.clock == clock
+                        && manifest.dimensions == self.dims
+                        && manifest
+                            .catalogs
+                            .iter()
+                            .all(|c| matches!(c.as_str(), "knowledge" | "statement"))
+                    {
+                        let loaded: Result<HashMap<_, _>> = manifest
+                            .catalogs
+                            .iter()
+                            .map(|c| {
+                                Ok((
+                                    c.clone(),
+                                    VectorFileIndex::load(&self.cache_file(clock, c), self.dims)?,
+                                ))
+                            })
+                            .collect();
+                        if let Ok(loaded) = loaded {
+                            *self.vectors.borrow_mut() = loaded;
+                            self.cache_clock.set(clock);
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+        let mut vectors = HashMap::new();
+        for catalog in ["knowledge", "statement"] {
+            let items: Vec<_> = self
+                .store
+                .embedding_pairs(catalog)?
+                .into_iter()
+                .map(|(id, b)| (id, super::sqlite_store::blob_to_vector(&b)))
+                .filter(|(_, v)| validate_vector(v, self.dims).is_ok())
+                .collect();
+            if !items.is_empty() {
+                vectors.insert(
+                    catalog.into(),
+                    VectorFileIndex::build(&self.cache_file(clock, catalog), self.dims, &items)?,
+                );
+            }
+        }
+        *self.vectors.borrow_mut() = vectors;
+        self.cache_clock.set(clock);
+        // Persistence is optional: usable in-memory indexes survive disk errors.
+        if let Err(e) = self.flush() {
+            eprintln!("warning: cannot persist vector cache; SQLite remains authoritative: {e}");
+        }
+        Ok(())
+    }
+    fn rebuild(&self) -> Result<()> {
+        let _snapshot = self.store.conn().unchecked_transaction()?;
+        let clock = self.clock()?;
+        self.refresh_snapshot(clock, true)
+    }
+    fn flush(&self) -> Result<()> {
+        if self.cache_clock.get() < 0 {
+            return Ok(());
+        }
+        std::fs::create_dir_all(&self.path)?;
+        let mut vectors = self.vectors.borrow_mut();
+        for idx in vectors.values_mut() {
+            idx.save()?;
+        }
+        let manifest = CacheManifest {
+            identity: self.cache_identity.clone(),
+            clock: self.cache_clock.get(),
+            dimensions: self.dims,
+            catalogs: vectors.keys().cloned().collect(),
+        };
+        super::vector_index::atomic_write(
+            &self.path.join("cache.json"),
+            &serde_json::to_vec(&manifest)?,
+        )?;
+        // Never remove another writer's newer generation. An older concurrent
+        // reader whose file disappears can rebuild from its own DB snapshot.
+        if let Ok(files) = std::fs::read_dir(&self.path) {
+            let prefix = format!("{}-", self.cache_identity);
+            for file in files.flatten() {
+                let name = file.file_name();
+                if let Some(rest) = name.to_str().and_then(|n| n.strip_prefix(&prefix)) {
+                    if let Some((old, _)) = rest.split_once('-') {
+                        if old.parse::<i64>().is_ok_and(|c| c < manifest.clock)
+                            && name.to_string_lossy().ends_with(".usearch")
+                        {
+                            let _ = std::fs::remove_file(file.path());
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+    fn search_vector(
+        &self,
+        target: QueryTarget,
+        vector: &[f32],
+        limit: i64,
+    ) -> Result<Vec<(String, String, f64)>> {
+        // RAII rollback releases this read-only snapshot on every return path.
+        // A writer cannot change the hydrated rows after our clock observation.
+        let _snapshot = self.store.conn().unchecked_transaction()?;
+        let clock = self.clock()?;
+        if self.store.embedding_metadata()?.is_none()
+            && self.store.embedding_row_count("knowledge")?
+                + self.store.embedding_row_count("statement")?
+                > 0
+        {
+            return Err(HypatiaError::Config("legacy vectors have unknown model identity; explicitly reembed before semantic search".into()));
+        }
+        if let Err(e) = self.refresh_snapshot(clock, false) {
+            eprintln!("warning: vector cache unavailable; using exact SQLite search: {e}");
+        }
+        let catalog = target.table_name();
+        if self.cache_clock.get() == clock {
+            if let Some(idx) = self.vectors.borrow().get(catalog) {
+                if let Ok(hits) = idx.search(vector, limit as usize) {
+                    if !hits.is_empty() {
+                        let ids: Vec<_> = hits.iter().map(|(id, _)| *id).collect();
+                        let mut rows: HashMap<_, _> = self
+                            .store
+                            .rows_by_doc_ids(catalog, &ids)?
+                            .into_iter()
+                            .map(|(id, k, c)| (id, (k, c)))
+                            .collect();
+                        return Ok(hits
+                            .into_iter()
+                            .filter_map(|(id, d)| rows.remove(&id).map(|(k, c)| (k, c, d)))
+                            .collect());
+                    }
+                }
+            }
+        }
+        match target {
+            QueryTarget::Knowledge => self.store.vector_search_knowledge(vector, limit),
+            QueryTarget::Statement => self.store.vector_search_statements(vector, limit),
+        }
+    }
+}
+impl ShelfBackend {
+    pub fn open(config: &ShelfConfig, settings: &ShelfSettings) -> Result<Self> {
+        settings.validate()?;
+        let dims = settings.embedding.dimensions();
+        let inner = match settings.storage.backend {
+            BackendKind::Sqlite => {
+                // Vector files are a disposable cache; disk failure must not disable CRUD.
+                let store = open_or_migrate(config)?;
+                if settings.embedding.model_identity_trusted {
+                    store.configure_embedding(&EmbeddingMetadata {
+                        model: settings.embedding.model_identity().into(),
+                        dimensions: dims,
+                        metric: "cosine".into(),
+                    })?;
+                }
+                store.conn().execute("INSERT OR IGNORE INTO meta(k,v) VALUES('cache_identity',lower(hex(randomblob(16))))",[])?;
+                let cache_identity: String = store.conn().query_row(
+                    "SELECT v FROM meta WHERE k='cache_identity'",
+                    [],
+                    |r| r.get(0),
+                )?;
+                if cache_identity.len() != 32
+                    || !cache_identity.bytes().all(|b| b.is_ascii_hexdigit())
+                {
+                    return Err(HypatiaError::Config("invalid local cache identity".into()));
+                }
+                let local = LocalBackend {
+                    store,
+                    vectors: std::cell::RefCell::new(HashMap::new()),
+                    path: config.vectors_path.clone(),
+                    dims,
+                    cache_clock: std::cell::Cell::new(-1),
+                    cache_identity,
+                };
+                // First search loads a matching persisted generation or rebuilds.
+                // Plain CRUD startup never scans embeddings or needs usearch files.
+                Backend::Local(local)
+            }
+            BackendKind::Pgvector => {
+                #[cfg(feature = "postgres-backend")]
+                {
+                    Backend::Postgres(super::postgres_store::PgStore::open(
+                        settings
+                            .storage
+                            .postgres
+                            .as_ref()
+                            .expect("validated PG config"),
+                        &settings.storage.vector,
+                        &settings.embedding,
+                    )?)
+                }
+                #[cfg(not(feature = "postgres-backend"))]
+                {
+                    return Err(HypatiaError::Config("this binary does not support pgvector; rebuild with --features postgres-backend".into()));
+                }
+            }
+        };
+        Ok(Self { inner, dims })
+    }
+    pub fn is_local(&self) -> bool {
+        matches!(self.inner, Backend::Local(_))
+    }
+    pub fn schema(&self) -> Option<&str> {
+        match &self.inner {
+            Backend::Local(_) => None,
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => Some(pg.schema()),
+        }
+    }
+    pub fn vector_search(
+        &self,
+        target: QueryTarget,
+        vector: &[f32],
+        limit: i64,
+    ) -> Result<Vec<(String, String, f64)>> {
+        validate_vector(vector, self.dims)?;
+        if limit < 0 {
+            return Err(HypatiaError::Validation("limit must be nonnegative".into()));
+        }
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+        match &self.inner {
+            Backend::Local(l) => l.search_vector(target, vector, limit),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => match target {
+                QueryTarget::Knowledge => pg.vector_search_knowledge(vector, limit),
+                QueryTarget::Statement => pg.vector_search_statements(vector, limit),
+            },
+        }
+    }
+    pub fn install_embedding(
+        &mut self,
+        catalog: &str,
+        key: &str,
+        version: i64,
+        vector: &[f32],
+    ) -> Result<bool> {
+        validate_vector(vector, self.dims)?;
+        match &mut self.inner {
+            Backend::Local(l) => {
+                if l.store.embedding_metadata()?.is_none() {
+                    return Err(HypatiaError::Config("legacy vectors have unknown model identity; explicitly reembed before embedding writeback".into()));
+                }
+                let installed = l.store.install_embedding(catalog, key, version, vector)?;
+                if installed {
+                    // The next search lazily loads or rebuilds a coherent generation.
+                    l.cache_clock.set(-1);
+                }
+                Ok(installed)
+            }
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.install_embedding(catalog, key, version, vector),
+        }
+    }
+    pub fn embeddings_identified(&self) -> Result<bool> {
+        match &self.inner {
+            Backend::Local(l) => Ok(l.store.embedding_metadata()?.is_some()),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(_) => Ok(true),
+        }
+    }
+
+    pub fn reset_embeddings(&mut self, metadata: &EmbeddingMetadata) -> Result<()> {
+        match &mut self.inner {
+            Backend::Local(l) => {
+                l.store.reset_embeddings(metadata)?;
+                l.cache_clock.set(-1);
+                Ok(())
+            }
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.clear_all_embeddings(),
+        }
+    }
+
+    pub fn rebuild_indexes(&mut self) -> Result<()> {
+        match &mut self.inner {
+            Backend::Local(l) => {
+                l.store.rebuild_json_index()?;
+                l.rebuild()
+            }
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.rebuild_indexes(),
+        }
+    }
+    pub fn flush(&mut self) -> Result<()> {
+        match &mut self.inner {
+            Backend::Local(l) => l.flush(),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(_) => Ok(()),
+        }
+    }
+    pub fn backup_local(&self, path: &Path) -> Result<()> {
+        match &self.inner {
+            Backend::Local(l) => l.store.backup_to(path),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(_) => Err(HypatiaError::Validation(
+                "PostgreSQL requires logical export".into(),
+            )),
+        }
+    }
+}
+impl Drop for ShelfBackend {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+impl ShelfBackend {
+    pub fn insert_knowledge(&self, name: &str, content: &Content) -> Result<i64> {
+        match &self.inner {
+            Backend::Local(l) => l.store.insert_knowledge(name, content),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.insert_knowledge(name, content),
+        }
+    }
+    pub fn get_knowledge(&self, name: &str) -> Result<Option<Knowledge>> {
+        match &self.inner {
+            Backend::Local(l) => l.store.get_knowledge(name),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.get_knowledge(name),
+        }
+    }
+    pub fn update_knowledge(&self, name: &str, content: &Content) -> Result<i64> {
+        match &self.inner {
+            Backend::Local(l) => l.store.update_knowledge(name, content),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.update_knowledge(name, content),
+        }
+    }
+    pub fn delete_knowledge(&self, name: &str) -> Result<()> {
+        match &self.inner {
+            Backend::Local(l) => l.store.delete_knowledge(name),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.delete_knowledge(name),
+        }
+    }
+    pub fn query_knowledge(&self, sql: &str, params: Vec<Value>) -> Result<Vec<Knowledge>> {
+        match &self.inner {
+            Backend::Local(l) => l.store.query_knowledge(sql, params),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.query_knowledge(sql, params),
+        }
+    }
+    pub fn insert_statement(
+        &self,
+        key: &StatementKey,
+        content: &Content,
+        tr_start: Option<NaiveDateTime>,
+        tr_end: Option<NaiveDateTime>,
+    ) -> Result<i64> {
+        match &self.inner {
+            Backend::Local(l) => l.store.insert_statement(key, content, tr_start, tr_end),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.insert_statement(key, content, tr_start, tr_end),
+        }
+    }
+    pub fn update_statement(
+        &self,
+        key: &StatementKey,
+        content: &Content,
+        tr_start: Option<NaiveDateTime>,
+        tr_end: Option<NaiveDateTime>,
+    ) -> Result<i64> {
+        match &self.inner {
+            Backend::Local(l) => l.store.update_statement(key, content, tr_start, tr_end),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.update_statement(key, content, tr_start, tr_end),
+        }
+    }
+    pub fn get_statement(&self, key: &StatementKey) -> Result<Option<Statement>> {
+        match &self.inner {
+            Backend::Local(l) => l.store.get_statement(key),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.get_statement(key),
+        }
+    }
+    pub fn delete_statement(&self, key: &StatementKey) -> Result<()> {
+        match &self.inner {
+            Backend::Local(l) => l.store.delete_statement(key),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.delete_statement(key),
+        }
+    }
+    pub fn query_statements(&self, sql: &str, params: Vec<Value>) -> Result<Vec<Statement>> {
+        match &self.inner {
+            Backend::Local(l) => l.store.query_statements(sql, params),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.query_statements(sql, params),
+        }
+    }
+    pub fn query_khop(
+        &self,
+        head: &str,
+        relation: Option<&str>,
+        depth: i64,
+    ) -> Result<Vec<Statement>> {
+        match &self.inner {
+            Backend::Local(l) => l.store.query_khop(head, relation, depth),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.query_khop(head, relation, depth),
+        }
+    }
+    pub fn search(&self, query: &str, opts: &SearchOpts) -> Result<Vec<super::FtsResult>> {
+        match &self.inner {
+            Backend::Local(l) => l.store.search(query, opts),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.search(query, opts),
+        }
+    }
+    pub fn embedding_version(&self, catalog: &str, key: &str) -> Result<Option<i64>> {
+        match &self.inner {
+            Backend::Local(l) => l.store.embedding_version(catalog, key),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.embedding_version(catalog, key),
+        }
+    }
+    pub fn missing_embeddings(
+        &self,
+        catalog: &str,
+        after_key: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(String, Content, i64)>> {
+        match &self.inner {
+            Backend::Local(l) => l.store.missing_embeddings(catalog, after_key, limit),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.missing_embeddings(catalog, after_key, limit),
+        }
+    }
+    pub fn embedding_row_count(&self, catalog: &str) -> Result<usize> {
+        match &self.inner {
+            Backend::Local(l) => l.store.embedding_row_count(catalog),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.embedding_row_count(catalog),
+        }
+    }
+    pub fn snapshot(&self) -> Result<Snapshot> {
+        match &self.inner {
+            Backend::Local(l) => l.store.snapshot(),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.snapshot(),
+        }
+    }
+    pub fn import_snapshot(&self, snapshot: &Snapshot) -> Result<()> {
+        match &self.inner {
+            Backend::Local(l) => l.store.import_snapshot(snapshot),
+            #[cfg(feature = "postgres-backend")]
+            Backend::Postgres(pg) => pg.import_snapshot(snapshot),
+        }
+    }
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::*;
+    fn local(dir: &Path) -> LocalBackend {
+        let store = SqliteStore::open(&dir.join("db.sqlite")).unwrap();
+        store
+            .configure_embedding(&EmbeddingMetadata {
+                model: "cache-test".into(),
+                dimensions: 2,
+                metric: "cosine".into(),
+            })
+            .unwrap();
+        LocalBackend {
+            store,
+            path: dir.join("vectors"),
+            dims: 2,
+            cache_clock: std::cell::Cell::new(-1),
+            vectors: std::cell::RefCell::new(HashMap::new()),
+            cache_identity: "0123456789abcdef0123456789abcdef".into(),
+        }
+    }
+    #[test]
+    fn cache_loads_persisted_generation_and_refreshes_after_external_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = local(dir.path());
+        let version = first
+            .store
+            .insert_knowledge("doc", &Content::new("old"))
+            .unwrap();
+        first
+            .store
+            .install_embedding("knowledge", "doc", version, &[1., 0.])
+            .unwrap();
+        first
+            .search_vector(QueryTarget::Knowledge, &[1., 0.], 1)
+            .unwrap();
+        let file = first.cache_file(first.cache_clock.get(), "knowledge");
+        let modified = std::fs::metadata(&file).unwrap().modified().unwrap();
+        let second = local(dir.path());
+        second
+            .search_vector(QueryTarget::Knowledge, &[1., 0.], 1)
+            .unwrap();
+        assert_eq!(
+            std::fs::metadata(&file).unwrap().modified().unwrap(),
+            modified,
+            "reopening must load rather than rewrite the index"
+        );
+        let version = first
+            .store
+            .update_knowledge("doc", &Content::new("new"))
+            .unwrap();
+        first
+            .store
+            .install_embedding("knowledge", "doc", version, &[0., 1.])
+            .unwrap();
+        let hits = second
+            .search_vector(QueryTarget::Knowledge, &[1., 0.], 1)
+            .unwrap();
+        assert_eq!(Content::from_json_str(&hits[0].1).unwrap().data, "new");
+        assert!(hits[0].2 > 0.99);
+        assert_eq!(second.cache_clock.get(), second.clock().unwrap());
+        assert!(!file.exists(), "obsolete generations should be collected");
+    }
+    #[test]
+    fn unwritable_cache_and_corrupt_manifest_do_not_disable_search() {
+        let dir = tempfile::tempdir().unwrap();
+        let l = local(dir.path());
+        let version = l
+            .store
+            .insert_knowledge("doc", &Content::new("hello"))
+            .unwrap();
+        l.store
+            .install_embedding("knowledge", "doc", version, &[1., 0.])
+            .unwrap();
+        std::fs::write(&l.path, b"file blocks cache directory").unwrap();
+        assert_eq!(
+            l.search_vector(QueryTarget::Knowledge, &[1., 0.], 1)
+                .unwrap()
+                .len(),
+            1
+        );
+        std::fs::remove_file(&l.path).unwrap();
+        std::fs::create_dir_all(&l.path).unwrap();
+        std::fs::write(l.path.join("cache.json"), b"not json").unwrap();
+        l.cache_clock.set(-1);
+        assert_eq!(
+            l.search_vector(QueryTarget::Knowledge, &[1., 0.], 1)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+    #[test]
+    fn concurrent_content_updates_never_pair_new_rows_with_old_distances() {
+        let dir = tempfile::tempdir().unwrap();
+        let l = local(dir.path());
+        let version = l.store.insert_knowledge("doc", &Content::new("a")).unwrap();
+        l.store
+            .install_embedding("knowledge", "doc", version, &[1., 0.])
+            .unwrap();
+        l.search_vector(QueryTarget::Knowledge, &[1., 0.], 1)
+            .unwrap();
+        let db = dir.path().join("db.sqlite");
+        let ready = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let writer_ready = ready.clone();
+        let writer = std::thread::spawn(move || {
+            let store = SqliteStore::open(&db).unwrap();
+            writer_ready.wait();
+            for i in 0..80 {
+                let (data, v) = if i % 2 == 0 {
+                    ("b", [0., 1.])
+                } else {
+                    ("a", [1., 0.])
+                };
+                let version = store.update_knowledge("doc", &Content::new(data)).unwrap();
+                store
+                    .install_embedding("knowledge", "doc", version, &v)
+                    .unwrap();
+            }
+        });
+        ready.wait();
+        for _ in 0..80 {
+            for (_, content, distance) in l
+                .search_vector(QueryTarget::Knowledge, &[1., 0.], 1)
+                .unwrap()
+            {
+                let data = Content::from_json_str(&content).unwrap().data;
+                assert!(
+                    (distance - if data == "a" { 0. } else { 1. }).abs() < 0.001,
+                    "row {data} has stale distance {distance}"
+                );
+            }
+        }
+        writer.join().unwrap();
+    }
+}

--- a/src/storage/json_index.rs
+++ b/src/storage/json_index.rs
@@ -18,7 +18,7 @@ use crate::error::{Result, StorageError};
 const RECURSE_BUDGET: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Posting {
+pub struct Posting {
     pub path: String,
     pub kind: &'static str,
     pub value: Option<String>,
@@ -72,7 +72,9 @@ pub fn content_postings(content_json: &str) -> Vec<Posting> {
 /// `format == "json"` payloads: index `data.<key>` for direct children.
 fn unpack_data(out: &mut Vec<Posting>, data_val: &Value) {
     let Value::String(s) = data_val else { return };
-    let Ok(parsed) = serde_json::from_str::<Value>(s) else { return };
+    let Ok(parsed) = serde_json::from_str::<Value>(s) else {
+        return;
+    };
     let Value::Object(map) = parsed else { return };
     for (key, val) in &map {
         let path = format!("data.{key}");
@@ -159,8 +161,11 @@ pub(crate) fn replace_postings_in(
     doc_id: i64,
     content_json: &str,
 ) -> Result<()> {
-    tx.execute("DELETE FROM json_index WHERE doc_id = ?1", rusqlite::params![doc_id])
-        .map_err(StorageError::from)?;
+    tx.execute(
+        "DELETE FROM json_index WHERE doc_id = ?1",
+        rusqlite::params![doc_id],
+    )
+    .map_err(StorageError::from)?;
     let postings = content_postings(content_json);
     for p in postings {
         tx.execute(
@@ -177,7 +182,8 @@ pub(crate) fn replace_postings_in(
 /// Returns the number of indexed documents.
 pub fn rebuild_all(conn: &rusqlite::Connection) -> Result<usize> {
     let tx = conn.unchecked_transaction().map_err(StorageError::from)?;
-    tx.execute("DELETE FROM json_index", []).map_err(StorageError::from)?;
+    tx.execute("DELETE FROM json_index", [])
+        .map_err(StorageError::from)?;
     let mut docs = 0usize;
     {
         let mut stmt = tx
@@ -191,9 +197,7 @@ pub fn rebuild_all(conn: &rusqlite::Connection) -> Result<usize> {
         let rows = stmt
             .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))
             .map_err(StorageError::from)?;
-        let pairs: Vec<(i64, String)> = rows
-            .filter_map(|r| r.ok())
-            .collect();
+        let pairs: Vec<(i64, String)> = rows.filter_map(|r| r.ok()).collect();
         for (id, content_json) in pairs {
             replace_postings_in(&tx, id, &content_json)?;
             docs += 1;
@@ -213,9 +217,9 @@ pub fn json_contains(lhs: &Value, rhs: &Value) -> bool {
         (Value::Object(a), Value::Object(b)) => b
             .iter()
             .all(|(k, rv)| a.get(k).map(|lv| json_contains(lv, rv)).unwrap_or(false)),
-        (Value::Array(a), Value::Array(b)) => b.iter().all(|rv| {
-            a.iter().any(|lv| json_contains(lv, rv))
-        }),
+        (Value::Array(a), Value::Array(b)) => {
+            b.iter().all(|rv| a.iter().any(|lv| json_contains(lv, rv)))
+        }
         // PG: scalar containment requires type AND value equality.
         _ => lhs == rhs,
     }
@@ -224,7 +228,10 @@ pub fn json_contains(lhs: &Value, rhs: &Value) -> bool {
 /// `json_contains(content_json, rhs_json)` over raw JSON texts; either side
 /// unparsable or NULL → false.
 pub fn json_contains_str(lhs: &str, rhs: &str) -> bool {
-    match (serde_json::from_str::<Value>(lhs), serde_json::from_str::<Value>(rhs)) {
+    match (
+        serde_json::from_str::<Value>(lhs),
+        serde_json::from_str::<Value>(rhs),
+    ) {
         (Ok(l), Ok(r)) => json_contains(&l, &r),
         _ => false,
     }
@@ -267,9 +274,7 @@ mod tests {
         let p = content_postings(content);
         // budget 2: root(1) -> meta(2) -> a would exceed → opaque leaf
         // budget exhausted one level deeper: array stored opaque
-        assert!(p
-            .iter()
-            .any(|x| x.path == "meta.a.b" && x.kind == "array"));
+        assert!(p.iter().any(|x| x.path == "meta.a.b" && x.kind == "array"));
     }
 
     #[test]
@@ -287,8 +292,14 @@ mod tests {
             &json!({"author":{"country":"CN"}})
         ));
         // array containment: every rhs element matched somewhere in lhs
-        assert!(json_contains(&json!({"tags":["a","b"]}), &json!({"tags":["a"]})));
-        assert!(!json_contains(&json!({"tags":["a"]}), &json!({"tags":["a","b"]})));
+        assert!(json_contains(
+            &json!({"tags":["a","b"]}),
+            &json!({"tags":["a"]})
+        ));
+        assert!(!json_contains(
+            &json!({"tags":["a"]}),
+            &json!({"tags":["a","b"]})
+        ));
         // strings require equality (PG), not substring (jq)
         assert!(!json_contains(&json!("abc"), &json!("b")));
         assert!(json_contains(&json!("abc"), &json!("abc")));

--- a/src/storage/migrate.rs
+++ b/src/storage/migrate.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use crate::error::Result;
 use crate::model::shelf::ShelfConfig;
-use crate::storage::sqlite_store::{fts_doc_for, vector_to_blob, SqliteStore};
+use crate::storage::sqlite_store::{SqliteStore, fts_doc_for, vector_to_blob};
 
 /// Open a shelf, migrating first when needed. The single entry point used by
 /// ShelfManager.
@@ -67,16 +67,15 @@ fn run_migration(config: &ShelfConfig, target: &Path) -> Result<()> {
     let config_duckdb = duckdb::Config::default()
         .access_mode(duckdb::AccessMode::ReadOnly)
         .map_err(crate::error::StorageError::from)?;
-    let legacy = duckdb::Connection::open_with_flags(
-        &config.legacy_duckdb_path(),
-        config_duckdb,
-    )
-    .map_err(crate::error::StorageError::from)?;
+    let legacy = duckdb::Connection::open_with_flags(&config.legacy_duckdb_path(), config_duckdb)
+        .map_err(crate::error::StorageError::from)?;
 
     let store = SqliteStore::open(target)?;
     let conn = store.conn();
 
-    let tx = conn.unchecked_transaction().map_err(crate::error::StorageError::from)?;
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(crate::error::StorageError::from)?;
 
     // ── knowledge ────────────────────────────────────────────────────
     // Embeddings are read as JSON text (to_json) for duckdb ARRAY portability.
@@ -171,11 +170,7 @@ fn parse_embedding(json: Option<String>) -> Result<Option<Vec<f32>>> {
         None => Ok(None),
         Some(s) => {
             let v: Vec<f32> = serde_json::from_str(&s)?;
-            if v.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(v))
-            }
+            if v.is_empty() { Ok(None) } else { Ok(Some(v)) }
         }
     }
 }
@@ -198,7 +193,14 @@ fn insert_docs_row(
     tx.execute(
         "INSERT INTO docs(catalog, key, fts_key, fts_data, fts_tags, fts_synonyms)
          VALUES(?1, ?2, ?3, ?4, ?5, ?6)",
-        rusqlite::params![catalog, key, doc.fts_key, doc.fts_data, doc.fts_tags, doc.fts_synonyms],
+        rusqlite::params![
+            catalog,
+            key,
+            doc.fts_key,
+            doc.fts_data,
+            doc.fts_tags,
+            doc.fts_synonyms
+        ],
     )
     .map_err(crate::error::StorageError::from)?;
     Ok(())
@@ -281,7 +283,12 @@ mod tests {
 
         // Legacy files renamed to .bak
         assert!(!config.legacy_duckdb_path().exists());
-        assert!(config.legacy_duckdb_path().with_extension("duckdb.bak").exists());
+        assert!(
+            config
+                .legacy_duckdb_path()
+                .with_extension("duckdb.bak")
+                .exists()
+        );
         assert!(!config.needs_migration());
 
         // New store contents
@@ -300,7 +307,9 @@ mod tests {
         assert_eq!(store.knowledge_with_embeddings().unwrap().len(), 1);
 
         // FTS index works after migration
-        let results = store.search("Rust", &crate::model::SearchOpts::default()).unwrap();
+        let results = store
+            .search("Rust", &crate::model::SearchOpts::default())
+            .unwrap();
         assert!(!results.is_empty());
 
         // Re-running is a no-op
@@ -314,7 +323,11 @@ mod tests {
         seed_legacy(&config.legacy_duckdb_path());
 
         // Simulate an interrupted run: partial output + leftover wal.
-        std::fs::write(config.sqlite_path.with_extension("sqlite.migrating"), b"junk").unwrap();
+        std::fs::write(
+            config.sqlite_path.with_extension("sqlite.migrating"),
+            b"junk",
+        )
+        .unwrap();
         std::fs::write(
             config.sqlite_path.with_extension("sqlite.migrating-wal"),
             b"junk",
@@ -325,7 +338,12 @@ mod tests {
 
         let store = SqliteStore::open(&config.sqlite_path).unwrap();
         assert!(store.get_knowledge("rust").unwrap().is_some());
-        assert!(!config.sqlite_path.with_extension("sqlite.migrating").exists());
+        assert!(
+            !config
+                .sqlite_path
+                .with_extension("sqlite.migrating")
+                .exists()
+        );
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,6 +1,11 @@
+pub mod backend;
 pub mod json_index;
 #[cfg(feature = "legacy-migration")]
 pub mod migrate;
+#[cfg(feature = "postgres-backend")]
+pub mod postgres_store;
+pub mod settings;
+pub mod transfer;
 #[cfg(not(feature = "legacy-migration"))]
 pub mod migrate {
     //! Stub: legacy duckdb→sqlite migration requires the
@@ -29,8 +34,17 @@ pub use json_index::json_contains;
 pub use migrate::open_or_migrate;
 pub use shelf_manager::{OpenShelf, ShelfManager};
 pub use shelf_registry::ShelfRegistry;
-pub use sqlite_store::{sanitize_fts_query, FtsDoc, SqliteStore};
+pub use sqlite_store::{FtsDoc, SqliteStore, sanitize_fts_query};
 pub use vector_index::VectorFileIndex;
+
+#[derive(Debug, Clone)]
+pub struct FtsResult {
+    pub id: i64,
+    pub catalog: String,
+    pub key: String,
+    pub content: String,
+    pub rank: f64,
+}
 
 use crate::error::Result;
 use crate::model::{QueryResult, QueryTarget, SearchOpts};
@@ -39,6 +53,16 @@ use crate::model::{QueryResult, QueryTarget, SearchOpts};
 /// OpenShelf implements this trait by delegating to the unified SQLite store.
 /// Note: No Send+Sync bounds because the connection uses RefCell internally.
 pub trait Storage {
+    /// SQL dialect accepted by execute_query; existing stores default to SQLite.
+    fn sql_dialect(&self) -> crate::engine::SqlDialect {
+        crate::engine::SqlDialect::Sqlite
+    }
+
+    /// PostgreSQL shelf schema. PostgreSQL queries require an explicit schema.
+    fn sql_schema(&self) -> Option<&str> {
+        None
+    }
+
     fn execute_query(
         &self,
         target: QueryTarget,
@@ -60,10 +84,5 @@ pub trait Storage {
     /// Execute a k-hop forward graph traversal starting from `head`,
     /// following edges with the given relation (or any relation if None),
     /// up to `depth` hops. Returns matching statement triples.
-    fn execute_khop(
-        &self,
-        head: &str,
-        relation: Option<&str>,
-        depth: i64,
-    ) -> Result<QueryResult>;
+    fn execute_khop(&self, head: &str, relation: Option<&str>, depth: i64) -> Result<QueryResult>;
 }

--- a/src/storage/postgres_store.rs
+++ b/src/storage/postgres_store.rs
@@ -1,0 +1,930 @@
+//! PostgreSQL source of truth. All shelf relations and extension objects are qualified.
+//! Versions use a non-cycling sequence, so delete/recreate cannot revive stale jobs.
+//!
+//! TLS uses native-tls defaults: platform trust roots and certificate/hostname
+//! verification are enabled. The driver accepts sslmode=disable/prefer/require;
+//! prefer is its default and permits plaintext when the server declines TLS.
+//! Use require to mandate TLS. libpq modes verify-ca/verify-full and sslrootcert
+//! connection options are unsupported and fail configuration parsing; they are
+//! not silently ignored. Custom roots/client identities are not configured here.
+use crate::{
+    embedding::EmbeddingConfig,
+    error::{HypatiaError, Result},
+    model::{Content, Knowledge, SearchOpts, Statement, StatementKey},
+    storage::{
+        settings::{PostgresSettings, VectorSettings},
+        transfer::{
+            EmbeddingMetadata, KnowledgeRecord, Snapshot, StatementRecord, validate_vector,
+        },
+    },
+};
+use chrono::NaiveDateTime;
+use pgvector::Vector;
+use postgres::{
+    Client, GenericClient, Row,
+    types::{ToSql, Type},
+};
+use serde_json::Value;
+use std::{cell::RefCell, time::Duration};
+
+use super::FtsResult;
+pub struct PgStore {
+    client: RefCell<Client>,
+    schema: String,
+    extension: String,
+    dimensions: usize,
+    model: String,
+}
+// Do not echo connection strings, SQL text, or server DETAIL (which can carry data).
+fn pg_error(e: postgres::Error) -> HypatiaError {
+    let code = e.code().map(|c| c.code()).unwrap_or("connection/protocol");
+    let reason = match code {
+        "23505" => "duplicate key",
+        "23502" | "23503" | "23514" => "data constraint violation",
+        "42501" => "insufficient database privileges",
+        "57014" => "statement cancelled or timeout exceeded",
+        "40P01" => "transaction deadlock; retry the operation",
+        "40001" => "serialization conflict; retry the operation",
+        "42P01" | "42703" | "42883" => "required database object or function is missing",
+        "28P01" | "28000" => "authentication failed",
+        "connection/protocol" => "connection or parameter encoding failure",
+        _ => "database operation failed",
+    };
+    let message = format!("PostgreSQL: {reason} ({code})");
+    if code.starts_with("23") {
+        HypatiaError::Validation(message)
+    } else {
+        HypatiaError::Config(message)
+    }
+}
+fn invalid(s: impl Into<String>) -> HypatiaError {
+    HypatiaError::Validation(s.into())
+}
+fn ident(s: &str) -> String {
+    format!("\"{}\"", s.replace('"', "\"\""))
+}
+fn catalog_info(catalog: &str) -> Result<(&'static str, &'static str)> {
+    match catalog {
+        "knowledge" => Ok(("knowledge", "name")),
+        "statement" => Ok(("statement", "triple")),
+        _ => Err(invalid("catalog must be knowledge or statement")),
+    }
+}
+fn validate_timestamp(value: NaiveDateTime) -> Result<()> {
+    use chrono::Timelike;
+    if value.nanosecond() % 1000 != 0 || value.nanosecond() >= 1_000_000_000 {
+        return Err(invalid(
+            "PostgreSQL timestamps require microsecond precision and do not preserve leap-second encodings",
+        ));
+    }
+    Ok(())
+}
+
+fn content_values(c: &Content) -> Result<(Value, Option<Value>, Value)> {
+    Ok((
+        serde_json::to_value(c)?,
+        serde_json::from_str(&c.data).ok(),
+        crate::engine::postgres::membership_tokens(&c.to_json_string()),
+    ))
+}
+fn knowledge_row(r: &Row) -> Result<Knowledge> {
+    Ok(Knowledge {
+        name: r.try_get("name").map_err(pg_error)?,
+        content: serde_json::from_value(r.try_get::<_, Value>("content").map_err(pg_error)?)?,
+        created_at: r.try_get("created_at").map_err(pg_error)?,
+    })
+}
+fn statement_row(r: &Row) -> Result<Statement> {
+    Ok(Statement {
+        key: StatementKey {
+            head: r.try_get("head").map_err(pg_error)?,
+            relation: r.try_get("relation").map_err(pg_error)?,
+            tail: r.try_get("tail").map_err(pg_error)?,
+        },
+        content: serde_json::from_value(r.try_get::<_, Value>("content").map_err(pg_error)?)?,
+        created_at: r.try_get("created_at").map_err(pg_error)?,
+        tr_start: r.try_get("tr_start").map_err(pg_error)?,
+        tr_end: r.try_get("tr_end").map_err(pg_error)?,
+    })
+}
+impl PgStore {
+    pub fn open(
+        config: &PostgresSettings,
+        vector: &VectorSettings,
+        embedding: &EmbeddingConfig,
+    ) -> Result<Self> {
+        super::settings::validate_schema(&config.schema)?;
+        if !embedding.model_identity_trusted {
+            return Err(HypatiaError::Config("PostgreSQL requires a trusted embedding model identity; configure embedding.model or readable model and tokenizer files".into()));
+        }
+        if vector.metric != "cosine" || !matches!(vector.index.as_str(), "hnsw" | "none") {
+            return Err(HypatiaError::Config(
+                "PostgreSQL vectors require metric=cosine and index=hnsw or none".into(),
+            ));
+        }
+        let dimensions = embedding.dimensions();
+        if dimensions == 0 || dimensions > 16000 || (vector.index == "hnsw" && dimensions > 2000) {
+            return Err(HypatiaError::Config(
+                "pgvector dimensions must be 1–16000 (HNSW maximum: 2000)".into(),
+            ));
+        }
+        if config.connect_timeout_seconds == 0
+            || config.statement_timeout_ms == 0
+            || config.statement_timeout_ms > i32::MAX as u64
+        {
+            return Err(HypatiaError::Config(
+                "PostgreSQL timeouts must be positive; statement timeout must fit i32 milliseconds"
+                    .into(),
+            ));
+        }
+        let url = config.connection_url()?;
+        let mut connection: postgres::Config = url.parse().map_err(|_| {
+            HypatiaError::Config("Invalid PostgreSQL connection configuration".into())
+        })?;
+        connection.connect_timeout(Duration::from_secs(config.connect_timeout_seconds));
+        let tls = native_tls::TlsConnector::builder()
+            .build()
+            .map_err(|_| HypatiaError::Config("Cannot initialize PostgreSQL TLS".into()))?;
+        let mut client = connection
+            .connect(postgres_native_tls::MakeTlsConnector::new(tls))
+            .map_err(pg_error)?;
+        client
+            .query_one(
+                "SELECT pg_catalog.set_config('statement_timeout',$1,false)",
+                &[&config.statement_timeout_ms.to_string()],
+            )
+            .map_err(pg_error)?;
+        client
+            .batch_execute("SET search_path = pg_catalog")
+            .map_err(pg_error)?;
+        let extension:String=client.query_opt("SELECT n.nspname FROM pg_catalog.pg_extension e JOIN pg_catalog.pg_namespace n ON n.oid=e.extnamespace WHERE e.extname='vector'",&[]).map_err(pg_error)?.ok_or_else(||HypatiaError::Config("The vector extension must be preinstalled by a database administrator".into()))?.get(0);
+        let store = Self {
+            client: RefCell::new(client),
+            schema: config.schema.clone(),
+            extension: ident(&extension),
+            dimensions,
+            model: embedding.model_identity().to_string(),
+        };
+        store.init_schema(&vector.index)?;
+        Ok(store)
+    }
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+    fn table(&self, t: &str) -> String {
+        format!("{}.{}", ident(&self.schema), ident(t))
+    }
+    fn init_schema(&self, index: &str) -> Result<()> {
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        tx.query_one(
+            "SELECT pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended($1,0))",
+            &[&format!("hypatia:{}", self.schema)],
+        )
+        .map_err(pg_error)?;
+        tx.batch_execute(&format!("CREATE SCHEMA IF NOT EXISTS {}; CREATE TABLE IF NOT EXISTS {}(k text PRIMARY KEY,v text NOT NULL)",ident(&self.schema),self.table("meta"))).map_err(pg_error)?;
+        let expected = [
+            ("schema_version", "1".to_string()),
+            ("embedding_model", self.model.clone()),
+            ("embedding_dimensions", self.dimensions.to_string()),
+            ("vector_metric", "cosine".to_string()),
+            ("vector_index", index.to_string()),
+        ];
+        let metadata = tx
+            .query(&format!("SELECT k,v FROM {}", self.table("meta")), &[])
+            .map_err(pg_error)?;
+        if !metadata.is_empty() {
+            for (key, value) in &expected {
+                if !metadata
+                    .iter()
+                    .any(|r| r.get::<_, String>(0) == *key && r.get::<_, String>(1) == *value)
+                {
+                    return Err(HypatiaError::Config(format!(
+                        "PostgreSQL shelf metadata mismatch: {key}; explicit migration or re-embedding is required"
+                    )));
+                }
+            }
+            for table in ["knowledge", "statement", "docs", "content_versions"] {
+                let exists: bool = tx
+                    .query_one(
+                        "SELECT pg_catalog.to_regclass($1) IS NOT NULL",
+                        &[&self.table(table)],
+                    )
+                    .map_err(pg_error)?
+                    .get(0);
+                if !exists {
+                    return Err(HypatiaError::Config(format!(
+                        "PostgreSQL shelf object missing: {table}"
+                    )));
+                }
+            }
+            self.validate_schema_structure(&mut tx, index)?;
+            return tx.commit().map_err(pg_error);
+        }
+        tx.batch_execute(&format!(r#"
+CREATE SEQUENCE {versions} AS bigint NO CYCLE;
+CREATE TABLE {docs}(id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,catalog text NOT NULL CHECK(catalog IN ('knowledge','statement')),key text NOT NULL,search_vector tsvector NOT NULL,UNIQUE(catalog,key));
+CREATE INDEX docs_search_idx ON {docs} USING gin(search_vector);
+CREATE TABLE {knowledge}(name text PRIMARY KEY,content jsonb NOT NULL,payload jsonb,tokens jsonb NOT NULL,created_at timestamp NOT NULL DEFAULT(CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),content_version bigint NOT NULL DEFAULT nextval('{versions}'::regclass),embedding {ext}.vector({dims}));
+CREATE TABLE {statement}(triple text PRIMARY KEY,head text NOT NULL,relation text NOT NULL,tail text NOT NULL,content jsonb NOT NULL,payload jsonb,tokens jsonb NOT NULL,created_at timestamp NOT NULL DEFAULT(CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),tr_start timestamp,tr_end timestamp,content_version bigint NOT NULL DEFAULT nextval('{versions}'::regclass),embedding {ext}.vector({dims}));
+CREATE INDEX knowledge_payload_idx ON {knowledge} USING gin(payload jsonb_path_ops);
+CREATE INDEX statement_payload_idx ON {statement} USING gin(payload jsonb_path_ops);
+CREATE INDEX statement_head_idx ON {statement}(head);
+CREATE INDEX statement_relation_idx ON {statement}(relation);
+CREATE INDEX statement_tail_idx ON {statement}(tail);
+CREATE INDEX knowledge_missing_embedding_idx ON {knowledge}(name) WHERE embedding IS NULL;
+CREATE INDEX statement_missing_embedding_idx ON {statement}(triple) WHERE embedding IS NULL;
+"#,versions=self.table("content_versions"),docs=self.table("docs"),knowledge=self.table("knowledge"),statement=self.table("statement"),ext=self.extension,dims=self.dimensions)).map_err(pg_error)?;
+        tx.batch_execute(&crate::engine::postgres::schema_functions(&self.schema))
+            .map_err(pg_error)?;
+        if index == "hnsw" {
+            for table in ["knowledge", "statement"] {
+                tx.batch_execute(&format!(
+                    "CREATE INDEX {} ON {} USING hnsw(embedding {}.vector_cosine_ops)",
+                    ident(&format!("{table}_embedding_hnsw_idx")),
+                    self.table(table),
+                    self.extension
+                ))
+                .map_err(pg_error)?;
+            }
+        }
+        for (key, value) in expected {
+            tx.execute(
+                &format!("INSERT INTO {}(k,v) VALUES($1,$2)", self.table("meta")),
+                &[&key, &value],
+            )
+            .map_err(pg_error)?;
+        }
+        tx.commit().map_err(pg_error)
+    }
+    fn validate_schema_structure(&self, tx: &mut impl GenericClient, index: &str) -> Result<()> {
+        for table in ["knowledge", "statement"] {
+            let rows = tx.query("SELECT a.attname,t.typname,n.nspname,a.atttypmod,a.attnotnull FROM pg_catalog.pg_attribute a JOIN pg_catalog.pg_type t ON t.oid=a.atttypid JOIN pg_catalog.pg_namespace n ON n.oid=t.typnamespace WHERE a.attrelid=pg_catalog.to_regclass($1) AND a.attnum>0 AND NOT a.attisdropped", &[&self.table(table)]).map_err(pg_error)?;
+            for (column, typ, not_null) in [
+                ("content", "jsonb", true),
+                ("payload", "jsonb", false),
+                ("tokens", "jsonb", true),
+                ("content_version", "int8", true),
+                ("embedding", "vector", false),
+            ] {
+                let valid = rows.iter().any(|r| {
+                    r.get::<_, String>(0) == column
+                        && r.get::<_, String>(1) == typ
+                        && r.get::<_, bool>(4) == not_null
+                        && if column == "embedding" {
+                            ident(&r.get::<_, String>(2)) == self.extension
+                                && r.get::<_, i32>(3) == self.dimensions as i32
+                        } else {
+                            r.get::<_, String>(2) == "pg_catalog"
+                        }
+                });
+                if !valid {
+                    return Err(HypatiaError::Config(format!(
+                        "PostgreSQL schema mismatch: {table}.{column}"
+                    )));
+                }
+            }
+            if index == "hnsw" {
+                let valid: bool = tx.query_one("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class c ON c.oid=i.indexrelid JOIN pg_catalog.pg_am a ON a.oid=c.relam JOIN pg_catalog.pg_opclass o ON o.oid=i.indclass[0] WHERE i.indexrelid=pg_catalog.to_regclass($1) AND i.indrelid=pg_catalog.to_regclass($2) AND i.indisvalid AND a.amname='hnsw' AND o.opcname='vector_cosine_ops')", &[&self.table(&format!("{table}_embedding_hnsw_idx")), &self.table(table)]).map_err(pg_error)?.get(0);
+                if !valid {
+                    return Err(HypatiaError::Config(format!(
+                        "PostgreSQL HNSW index is missing or invalid: {table}"
+                    )));
+                }
+            }
+        }
+        for signature in [
+            "jse_numeric(text)",
+            "jse_json_contains(jsonb,jsonb)",
+            "jse_compact(jsonb)",
+        ] {
+            let qualified = format!("{}.{}", ident(&self.schema), signature);
+            let exists: bool = tx
+                .query_one(
+                    "SELECT pg_catalog.to_regprocedure($1) IS NOT NULL",
+                    &[&qualified],
+                )
+                .map_err(pg_error)?
+                .get(0);
+            if !exists {
+                return Err(HypatiaError::Config(format!(
+                    "PostgreSQL helper function missing: {signature}"
+                )));
+            }
+        }
+        Ok(())
+    }
+    fn upsert_doc(
+        &self,
+        tx: &mut impl GenericClient,
+        catalog: &str,
+        key: &str,
+        content: &Content,
+    ) -> Result<()> {
+        let f = content.fts_fields(key);
+        tx.execute(&format!("INSERT INTO {}(catalog,key,search_vector) VALUES($1,$2,setweight(to_tsvector('pg_catalog.simple'::regconfig,$3),'A') || setweight(to_tsvector('pg_catalog.simple'::regconfig,$4),'D') || setweight(to_tsvector('pg_catalog.simple'::regconfig,$5),'B') || setweight(to_tsvector('pg_catalog.simple'::regconfig,$6),'C')) ON CONFLICT(catalog,key) DO UPDATE SET search_vector=excluded.search_vector",self.table("docs")),&[&catalog,&key,&f.key,&f.data,&f.tags,&f.synonyms]).map_err(pg_error)?;
+        Ok(())
+    }
+    pub fn insert_knowledge(&self, name: &str, content: &Content) -> Result<i64> {
+        let (raw, payload, tokens) = content_values(content)?;
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        let token=tx.query_one(&format!("INSERT INTO {}(name,content,payload,tokens) VALUES($1,$2,$3,$4) RETURNING content_version",self.table("knowledge")),&[&name,&raw,&payload,&tokens]).map_err(pg_error)?.get(0);
+        self.upsert_doc(&mut tx, "knowledge", name, content)?;
+        tx.commit().map_err(pg_error)?;
+        Ok(token)
+    }
+    pub fn update_knowledge(&self, name: &str, content: &Content) -> Result<i64> {
+        let (raw, payload, tokens) = content_values(content)?;
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        let token=tx.query_opt(&format!("UPDATE {} SET content=$2,payload=$3,tokens=$4,embedding=NULL,content_version=nextval('{}'::regclass) WHERE name=$1 RETURNING content_version",self.table("knowledge"),self.table("content_versions")),&[&name,&raw,&payload,&tokens]).map_err(pg_error)?.ok_or_else(||HypatiaError::NotFound{kind:"knowledge".into(),key:name.into()})?.get(0);
+        self.upsert_doc(&mut tx, "knowledge", name, content)?;
+        tx.commit().map_err(pg_error)?;
+        Ok(token)
+    }
+    pub fn get_knowledge(&self, name: &str) -> Result<Option<Knowledge>> {
+        self.client
+            .borrow_mut()
+            .query_opt(
+                &format!(
+                    "SELECT name,content,created_at FROM {} WHERE name=$1",
+                    self.table("knowledge")
+                ),
+                &[&name],
+            )
+            .map_err(pg_error)?
+            .as_ref()
+            .map(knowledge_row)
+            .transpose()
+    }
+    pub fn insert_statement(
+        &self,
+        key: &StatementKey,
+        content: &Content,
+        tr_start: Option<NaiveDateTime>,
+        tr_end: Option<NaiveDateTime>,
+    ) -> Result<i64> {
+        for value in [tr_start, tr_end].into_iter().flatten() {
+            validate_timestamp(value)?;
+        }
+        let (raw, payload, tokens) = content_values(content)?;
+        let triple = key.to_csv_key();
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        let token=tx.query_one(&format!("INSERT INTO {}(triple,head,relation,tail,content,payload,tr_start,tr_end,tokens) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING content_version",self.table("statement")),&[&triple,&key.head,&key.relation,&key.tail,&raw,&payload,&tr_start,&tr_end,&tokens]).map_err(pg_error)?.get(0);
+        self.upsert_doc(&mut tx, "statement", &triple, content)?;
+        tx.commit().map_err(pg_error)?;
+        Ok(token)
+    }
+    pub fn update_statement(
+        &self,
+        key: &StatementKey,
+        content: &Content,
+        tr_start: Option<NaiveDateTime>,
+        tr_end: Option<NaiveDateTime>,
+    ) -> Result<i64> {
+        for value in [tr_start, tr_end].into_iter().flatten() {
+            validate_timestamp(value)?;
+        }
+        let (raw, payload, tokens) = content_values(content)?;
+        let triple = key.to_csv_key();
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        let token=tx.query_opt(&format!("UPDATE {} SET content=$2,payload=$3,tr_start=$4,tr_end=$5,tokens=$6,embedding=NULL,content_version=nextval('{}'::regclass) WHERE triple=$1 RETURNING content_version",self.table("statement"),self.table("content_versions")),&[&triple,&raw,&payload,&tr_start,&tr_end,&tokens]).map_err(pg_error)?.ok_or_else(||HypatiaError::NotFound{kind:"statement".into(),key:triple.clone()})?.get(0);
+        self.upsert_doc(&mut tx, "statement", &triple, content)?;
+        tx.commit().map_err(pg_error)?;
+        Ok(token)
+    }
+    pub fn get_statement(&self, key: &StatementKey) -> Result<Option<Statement>> {
+        self.client
+            .borrow_mut()
+            .query_opt(
+                &format!("SELECT * FROM {} WHERE triple=$1", self.table("statement")),
+                &[&key.to_csv_key()],
+            )
+            .map_err(pg_error)?
+            .as_ref()
+            .map(statement_row)
+            .transpose()
+    }
+    fn delete(&self, catalog: &str, key: &str) -> Result<()> {
+        let (table, pk) = catalog_info(catalog)?;
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        if tx
+            .execute(
+                &format!("DELETE FROM {} WHERE {pk}=$1", self.table(table)),
+                &[&key],
+            )
+            .map_err(pg_error)?
+            == 0
+        {
+            return Err(HypatiaError::NotFound {
+                kind: catalog.into(),
+                key: key.into(),
+            });
+        }
+        tx.execute(
+            &format!(
+                "DELETE FROM {} WHERE catalog=$1 AND key=$2",
+                self.table("docs")
+            ),
+            &[&catalog, &key],
+        )
+        .map_err(pg_error)?;
+        tx.commit().map_err(pg_error)
+    }
+    pub fn delete_knowledge(&self, name: &str) -> Result<()> {
+        self.delete("knowledge", name)
+    }
+    pub fn delete_statement(&self, key: &StatementKey) -> Result<()> {
+        self.delete("statement", &key.to_csv_key())
+    }
+    fn query(&self, sql: &str, values: Vec<Value>) -> Result<Vec<Row>> {
+        let mut client = self.client.borrow_mut();
+        let stmt = client.prepare(sql).map_err(pg_error)?;
+        if values.len() != stmt.params().len() {
+            return Err(invalid("query parameter count mismatch"));
+        }
+        let params: Vec<Box<dyn ToSql + Sync>> = values
+            .iter()
+            .zip(stmt.params())
+            .map(|(v, t)| parameter(v, t))
+            .collect::<Result<_>>()?;
+        let refs: Vec<&(dyn ToSql + Sync)> = params.iter().map(|p| p.as_ref()).collect();
+        client.query(&stmt, &refs).map_err(pg_error)
+    }
+    pub fn query_knowledge(&self, sql: &str, params: Vec<Value>) -> Result<Vec<Knowledge>> {
+        self.query(sql, params)?.iter().map(knowledge_row).collect()
+    }
+    pub fn query_statements(&self, sql: &str, params: Vec<Value>) -> Result<Vec<Statement>> {
+        self.query(sql, params)?.iter().map(statement_row).collect()
+    }
+    pub fn query_khop(
+        &self,
+        head: &str,
+        relation: Option<&str>,
+        depth: i64,
+    ) -> Result<Vec<Statement>> {
+        if depth <= 0 {
+            return Ok(vec![]);
+        }
+        if depth > 100 {
+            return Err(invalid("k-hop depth cannot exceed 100"));
+        }
+        // UNION deduplicates identical (edge,depth) states, bounding cyclic expansion.
+        let sql = format!(
+            "WITH RECURSIVE hop AS (SELECT triple,tail,1::bigint AS depth FROM {s} WHERE head=$1 AND ($2::text IS NULL OR relation=$2) UNION SELECT s.triple,s.tail,h.depth+1 FROM hop h JOIN {s} s ON s.head=h.tail WHERE h.depth<$3 AND ($2::text IS NULL OR s.relation=$2)), nearest AS (SELECT triple,min(depth) AS depth FROM hop GROUP BY triple) SELECT s.* FROM nearest n JOIN {s} s ON s.triple=n.triple ORDER BY n.depth,s.created_at DESC,s.triple",
+            s = self.table("statement")
+        );
+        self.client
+            .borrow_mut()
+            .query(&sql, &[&head, &relation, &depth])
+            .map_err(pg_error)?
+            .iter()
+            .map(statement_row)
+            .collect()
+    }
+    pub fn embedding_version(&self, catalog: &str, key: &str) -> Result<Option<i64>> {
+        let (table, pk) = catalog_info(catalog)?;
+        Ok(self
+            .client
+            .borrow_mut()
+            .query_opt(
+                &format!(
+                    "SELECT content_version FROM {} WHERE {pk}=$1",
+                    self.table(table)
+                ),
+                &[&key],
+            )
+            .map_err(pg_error)?
+            .map(|r| r.get(0)))
+    }
+    /// Single conditional UPDATE is the linearization point for background work.
+    pub fn install_embedding(
+        &self,
+        catalog: &str,
+        key: &str,
+        version: i64,
+        vector: &[f32],
+    ) -> Result<bool> {
+        let (table, pk) = catalog_info(catalog)?;
+        validate_vector(vector, self.dimensions)?;
+        let vector = Vector::from(vector.to_vec());
+        Ok(self
+            .client
+            .borrow_mut()
+            .execute(
+                &format!(
+                    "UPDATE {} SET embedding=$3 WHERE {pk}=$1 AND content_version=$2",
+                    self.table(table)
+                ),
+                &[&key, &version, &vector],
+            )
+            .map_err(pg_error)?
+            == 1)
+    }
+    /// Explicit re-embedding reset. Every row receives a new token, including
+    /// already-missing embeddings, so all outstanding workers are invalidated.
+    pub fn clear_all_embeddings(&self) -> Result<()> {
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        for table in ["knowledge", "statement"] {
+            tx.execute(
+                &format!(
+                    "UPDATE {} SET embedding=NULL,content_version=nextval('{}'::regclass)",
+                    self.table(table),
+                    self.table("content_versions")
+                ),
+                &[],
+            )
+            .map_err(pg_error)?;
+        }
+        tx.commit().map_err(pg_error)
+    }
+    fn clear_embedding(&self, catalog: &str, key: &str) -> Result<()> {
+        let (table, pk) = catalog_info(catalog)?;
+        self.client.borrow_mut().execute(&format!("UPDATE {} SET embedding=NULL,content_version=nextval('{}'::regclass) WHERE {pk}=$1",self.table(table),self.table("content_versions")),&[&key]).map_err(pg_error)?;
+        Ok(())
+    }
+    pub fn clear_knowledge_embedding(&self, name: &str) -> Result<()> {
+        self.clear_embedding("knowledge", name)
+    }
+    pub fn clear_statement_embedding(&self, triple: &str) -> Result<()> {
+        self.clear_embedding("statement", triple)
+    }
+    pub fn missing_embeddings(
+        &self,
+        catalog: &str,
+        after_key: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(String, Content, i64)>> {
+        let (table, pk) = catalog_info(catalog)?;
+        if limit < 0 {
+            return Err(invalid("embedding page limit must be nonnegative"));
+        }
+        self.client.borrow_mut().query(&format!("SELECT {pk},content,content_version FROM {} WHERE embedding IS NULL AND ($1::text IS NULL OR {pk}>$1) ORDER BY {pk} LIMIT $2",self.table(table)),&[&after_key,&limit]).map_err(pg_error)?.iter().map(|r|Ok((r.get(0),serde_json::from_value(r.get(1))?,r.get(2)))).collect()
+    }
+    fn entries(&self, catalog: &str, present: bool) -> Result<Vec<(String, String)>> {
+        let (table, pk) = catalog_info(catalog)?;
+        Ok(self.client.borrow_mut().query(&format!("SELECT {pk},content::text FROM {} WHERE (embedding IS NOT NULL)=$1 ORDER BY {pk}",self.table(table)),&[&present]).map_err(pg_error)?.iter().map(|r|(r.get(0),r.get(1))).collect())
+    }
+    pub fn knowledge_with_embeddings(&self) -> Result<Vec<(String, String)>> {
+        self.entries("knowledge", true)
+    }
+    pub fn knowledge_without_embeddings(&self) -> Result<Vec<(String, String)>> {
+        self.entries("knowledge", false)
+    }
+    pub fn statements_without_embeddings(&self) -> Result<Vec<(String, String)>> {
+        self.entries("statement", false)
+    }
+    pub fn embedding_row_count(&self, catalog: &str) -> Result<usize> {
+        let (table, _) = catalog_info(catalog)?;
+        let n: i64 = self
+            .client
+            .borrow_mut()
+            .query_one(
+                &format!(
+                    "SELECT count(*) FROM {} WHERE embedding IS NOT NULL",
+                    self.table(table)
+                ),
+                &[],
+            )
+            .map_err(pg_error)?
+            .get(0);
+        Ok(n as usize)
+    }
+    pub fn doc_id_by_key(&self, catalog: &str, key: &str) -> Result<Option<i64>> {
+        catalog_info(catalog)?;
+        Ok(self
+            .client
+            .borrow_mut()
+            .query_opt(
+                &format!(
+                    "SELECT id FROM {} WHERE catalog=$1 AND key=$2",
+                    self.table("docs")
+                ),
+                &[&catalog, &key],
+            )
+            .map_err(pg_error)?
+            .map(|r| r.get(0)))
+    }
+    pub fn rows_by_doc_ids(
+        &self,
+        catalog: &str,
+        ids: &[i64],
+    ) -> Result<Vec<(i64, String, String)>> {
+        let (table, pk) = catalog_info(catalog)?;
+        Ok(self.client.borrow_mut().query(&format!("SELECT d.id,s.{pk},s.content::text FROM {} s JOIN {} d ON d.key=s.{pk} AND d.catalog=$1 WHERE d.id=ANY($2)",self.table(table),self.table("docs")),&[&catalog,&ids]).map_err(pg_error)?.iter().map(|r|(r.get(0),r.get(1),r.get(2))).collect())
+    }
+    fn vector_search(
+        &self,
+        catalog: &str,
+        vector: &[f32],
+        limit: i64,
+    ) -> Result<Vec<(String, String, f64)>> {
+        let (table, pk) = catalog_info(catalog)?;
+        validate_vector(vector, self.dimensions)?;
+        if limit < 0 {
+            return Err(invalid("vector search limit must be nonnegative"));
+        }
+        let vector = Vector::from(vector.to_vec());
+        // Bare distance ORDER BY plus LIMIT permits the HNSW access path.
+        Ok(self.client.borrow_mut().query(&format!("SELECT {pk},content::text,embedding OPERATOR({ext}.<=>) $1 AS distance FROM {table} WHERE embedding IS NOT NULL ORDER BY embedding OPERATOR({ext}.<=>) $1 LIMIT $2",table=self.table(table),ext=self.extension),&[&vector,&limit]).map_err(pg_error)?.iter().map(|r|(r.get(0),r.get(1),r.get(2))).collect())
+    }
+    pub fn vector_search_knowledge(
+        &self,
+        vector: &[f32],
+        limit: i64,
+    ) -> Result<Vec<(String, String, f64)>> {
+        self.vector_search("knowledge", vector, limit)
+    }
+    pub fn vector_search_statements(
+        &self,
+        vector: &[f32],
+        limit: i64,
+    ) -> Result<Vec<(String, String, f64)>> {
+        self.vector_search("statement", vector, limit)
+    }
+    pub fn search(&self, query: &str, opts: &SearchOpts) -> Result<Vec<FtsResult>> {
+        if opts.limit < 0 || opts.offset < 0 {
+            return Err(invalid("search limit and offset must be nonnegative"));
+        }
+        if let Some(c) = opts.catalog.as_deref() {
+            catalog_info(c)?;
+        }
+        let segmented = crate::text::segment_for_fts(query);
+        let mut quoted = false;
+        let query = segmented
+            .split_whitespace()
+            .filter(|word| {
+                let explicit_and = !quoted && *word == "AND";
+                if word.chars().filter(|c| *c == '"').count() % 2 == 1 {
+                    quoted = !quoted;
+                }
+                !explicit_and
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        // PG weights are D,C,B,A and in [0,1]. Preserve 1:3:5:10 and lower-is-better.
+        let sql = format!(
+            "SELECT d.id,d.catalog,d.key,COALESCE(k.content,s.content)::text AS content,-ts_rank(ARRAY[0.1,0.3,0.5,1.0]::real[],d.search_vector,q.query)::double precision AS rank FROM {docs} d CROSS JOIN websearch_to_tsquery('pg_catalog.simple'::regconfig,$1) AS q(query) LEFT JOIN {knowledge} k ON d.catalog='knowledge' AND k.name=d.key LEFT JOIN {statement} s ON d.catalog='statement' AND s.triple=d.key WHERE d.search_vector @@ q.query AND ($2::text IS NULL OR d.catalog=$2) ORDER BY rank,d.id LIMIT $3 OFFSET $4",
+            docs = self.table("docs"),
+            knowledge = self.table("knowledge"),
+            statement = self.table("statement")
+        );
+        Ok(self
+            .client
+            .borrow_mut()
+            .query(&sql, &[&query, &opts.catalog, &opts.limit, &opts.offset])
+            .map_err(pg_error)?
+            .iter()
+            .map(|r| FtsResult {
+                id: r.get("id"),
+                catalog: r.get("catalog"),
+                key: r.get("key"),
+                content: r.get("content"),
+                rank: r.get("rank"),
+            })
+            .collect())
+    }
+    pub fn rebuild_indexes(&self) -> Result<()> {
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        tx.batch_execute(&format!(
+            "LOCK TABLE {},{},{} IN EXCLUSIVE MODE",
+            self.table("knowledge"),
+            self.table("statement"),
+            self.table("docs")
+        ))
+        .map_err(pg_error)?;
+        for (table, pk) in [("knowledge", "name"), ("statement", "triple")] {
+            for row in tx
+                .query(
+                    &format!("SELECT {pk},content FROM {}", self.table(table)),
+                    &[],
+                )
+                .map_err(pg_error)?
+            {
+                let key: String = row.get(0);
+                let content: Content = serde_json::from_value(row.get(1))?;
+                let (_, payload, tokens) = content_values(&content)?;
+                tx.execute(
+                    &format!(
+                        "UPDATE {} SET payload=$2,tokens=$3 WHERE {pk}=$1",
+                        self.table(table)
+                    ),
+                    &[&key, &payload, &tokens],
+                )
+                .map_err(pg_error)?;
+                self.upsert_doc(&mut tx, table, &key, &content)?;
+            }
+            tx.batch_execute(&format!("REINDEX TABLE {}", self.table(table)))
+                .map_err(pg_error)?;
+        }
+        tx.batch_execute(&format!("REINDEX TABLE {}", self.table("docs")))
+            .map_err(pg_error)?;
+        tx.commit().map_err(pg_error)
+    }
+    pub fn snapshot(&self) -> Result<Snapshot> {
+        let mut client = self.client.borrow_mut();
+        let mut tx = client
+            .build_transaction()
+            .isolation_level(postgres::IsolationLevel::RepeatableRead)
+            .read_only(true)
+            .start()
+            .map_err(pg_error)?;
+        let knowledge = tx
+            .query(
+                &format!("SELECT * FROM {} ORDER BY name", self.table("knowledge")),
+                &[],
+            )
+            .map_err(pg_error)?
+            .iter()
+            .map(|r| {
+                Ok(KnowledgeRecord {
+                    knowledge: knowledge_row(r)?,
+                    embedding: r
+                        .try_get::<_, Option<Vector>>("embedding")
+                        .map_err(pg_error)?
+                        .map(|v| v.to_vec()),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let statements = tx
+            .query(
+                &format!("SELECT * FROM {} ORDER BY triple", self.table("statement")),
+                &[],
+            )
+            .map_err(pg_error)?
+            .iter()
+            .map(|r| {
+                Ok(StatementRecord {
+                    statement: statement_row(r)?,
+                    embedding: r
+                        .try_get::<_, Option<Vector>>("embedding")
+                        .map_err(pg_error)?
+                        .map(|v| v.to_vec()),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        tx.commit().map_err(pg_error)?;
+        Ok(Snapshot {
+            format_version: 1,
+            embedding: Some(EmbeddingMetadata {
+                model: self.model.clone(),
+                dimensions: self.dimensions,
+                metric: "cosine".into(),
+            }),
+            knowledge,
+            statements,
+        })
+    }
+    pub fn import_snapshot(&self, snapshot: &Snapshot) -> Result<()> {
+        snapshot.validate()?;
+        for record in &snapshot.knowledge {
+            validate_timestamp(record.knowledge.created_at)?;
+        }
+        for record in &snapshot.statements {
+            let s = &record.statement;
+            for value in [Some(s.created_at), s.tr_start, s.tr_end]
+                .into_iter()
+                .flatten()
+            {
+                validate_timestamp(value)?;
+            }
+        }
+        if let Some(meta) = &snapshot.embedding {
+            if meta.model != self.model
+                || meta.dimensions != self.dimensions
+                || meta.metric != "cosine"
+            {
+                return Err(invalid(
+                    "snapshot embedding metadata does not match target shelf",
+                ));
+            }
+        }
+        let mut client = self.client.borrow_mut();
+        let mut tx = client.transaction().map_err(pg_error)?;
+        tx.batch_execute(&format!(
+            "LOCK TABLE {},{},{} IN EXCLUSIVE MODE",
+            self.table("knowledge"),
+            self.table("statement"),
+            self.table("docs")
+        ))
+        .map_err(pg_error)?;
+        let occupied:bool=tx.query_one(&format!("SELECT EXISTS(SELECT 1 FROM {}) OR EXISTS(SELECT 1 FROM {}) OR EXISTS(SELECT 1 FROM {})",self.table("knowledge"),self.table("statement"),self.table("docs")),&[]).map_err(pg_error)?.get(0);
+        if occupied {
+            return Err(invalid("snapshot import requires an empty target shelf"));
+        }
+        for record in &snapshot.knowledge {
+            let k = &record.knowledge;
+            let (raw, payload, tokens) = content_values(&k.content)?;
+            let embedding = record.embedding.clone().map(Vector::from);
+            tx.execute(&format!("INSERT INTO {}(name,content,payload,created_at,embedding,tokens) VALUES($1,$2,$3,$4,$5,$6)",self.table("knowledge")),&[&k.name,&raw,&payload,&k.created_at,&embedding,&tokens]).map_err(pg_error)?;
+            self.upsert_doc(&mut tx, "knowledge", &k.name, &k.content)?;
+        }
+        for record in &snapshot.statements {
+            let s = &record.statement;
+            let triple = s.key.to_csv_key();
+            let (raw, payload, tokens) = content_values(&s.content)?;
+            let embedding = record.embedding.clone().map(Vector::from);
+            tx.execute(&format!("INSERT INTO {}(triple,head,relation,tail,content,payload,created_at,tr_start,tr_end,embedding,tokens) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)",self.table("statement")),&[&triple,&s.key.head,&s.key.relation,&s.key.tail,&raw,&payload,&s.created_at,&s.tr_start,&s.tr_end,&embedding,&tokens]).map_err(pg_error)?;
+            self.upsert_doc(&mut tx, "statement", &triple, &s.content)?;
+        }
+        tx.commit().map_err(pg_error)
+    }
+}
+#[cfg(test)]
+mod timestamp_tests {
+    use super::*;
+    #[test]
+    fn rejects_precision_loss_before_database_write() {
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        assert!(validate_timestamp(date.and_hms_nano_opt(0, 0, 0, 123456000).unwrap()).is_ok());
+        assert!(validate_timestamp(date.and_hms_nano_opt(0, 0, 0, 123456001).unwrap()).is_err());
+    }
+}
+
+fn parameter(value: &Value, ty: &Type) -> Result<Box<dyn ToSql + Sync>> {
+    macro_rules! typed {
+        ($t:ty,$v:expr) => {{
+            let v: Option<$t> = if value.is_null() { None } else { Some($v) };
+            return Ok(Box::new(v));
+        }};
+    }
+    let bad = || {
+        invalid(format!(
+            "query parameter cannot be converted to PostgreSQL {}",
+            ty.name()
+        ))
+    };
+    match *ty {
+        Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME | Type::UNKNOWN => {
+            typed!(String, value.as_str().ok_or_else(bad)?.to_string())
+        }
+        Type::BOOL => typed!(bool, value.as_bool().ok_or_else(bad)?),
+        Type::INT2 => typed!(
+            i16,
+            i16::try_from(value.as_i64().ok_or_else(bad)?).map_err(|_| bad())?
+        ),
+        Type::INT4 => typed!(
+            i32,
+            i32::try_from(value.as_i64().ok_or_else(bad)?).map_err(|_| bad())?
+        ),
+        Type::INT8 => typed!(i64, value.as_i64().ok_or_else(bad)?),
+        Type::FLOAT4 => {
+            let n = value.as_f64().unwrap_or(0.0) as f32;
+            if !value.is_null() && (!value.is_number() || !n.is_finite()) {
+                return Err(bad());
+            }
+            typed!(f32, n)
+        }
+        Type::FLOAT8 => typed!(f64, value.as_f64().ok_or_else(bad)?),
+        Type::JSON | Type::JSONB => Ok(Box::new(value.clone())),
+        Type::TEXT_ARRAY | Type::VARCHAR_ARRAY => typed!(
+            Vec<String>,
+            value
+                .as_array()
+                .ok_or_else(bad)?
+                .iter()
+                .map(|v| v.as_str().map(str::to_string).ok_or_else(bad))
+                .collect::<Result<Vec<_>>>()?
+        ),
+        Type::INT8_ARRAY => typed!(
+            Vec<i64>,
+            value
+                .as_array()
+                .ok_or_else(bad)?
+                .iter()
+                .map(|v| v.as_i64().ok_or_else(bad))
+                .collect::<Result<Vec<_>>>()?
+        ),
+        Type::TIMESTAMP => typed!(
+            NaiveDateTime,
+            parse_timestamp(value.as_str().ok_or_else(bad)?)?
+        ),
+        Type::TIMESTAMPTZ => typed!(
+            chrono::DateTime<chrono::Utc>,
+            chrono::DateTime::parse_from_rfc3339(value.as_str().ok_or_else(bad)?)
+                .map_err(|_| bad())?
+                .with_timezone(&chrono::Utc)
+        ),
+        Type::DATE => typed!(
+            chrono::NaiveDate,
+            chrono::NaiveDate::parse_from_str(value.as_str().ok_or_else(bad)?, "%Y-%m-%d")
+                .map_err(|_| bad())?
+        ),
+        _ => Err(invalid(format!(
+            "unsupported PostgreSQL query parameter type: {}",
+            ty.name()
+        ))),
+    }
+}
+fn parse_timestamp(text: &str) -> Result<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(text, "%Y-%m-%d %H:%M:%S%.f")
+        .or_else(|_| NaiveDateTime::parse_from_str(text, "%Y-%m-%dT%H:%M:%S%.f"))
+        .or_else(|_| chrono::DateTime::parse_from_rfc3339(text).map(|t| t.naive_utc()))
+        .map_err(|_| invalid("invalid timestamp query parameter"))
+}

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -1,0 +1,276 @@
+//! Strict shelf configuration: validate before creating any backend resources.
+use crate::embedding::{EmbeddingConfig, config::EmbeddingToml};
+use crate::error::{HypatiaError, Result};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct ShelfSettings {
+    pub storage: StorageSettings,
+    pub embedding: EmbeddingConfig,
+}
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct StorageSettings {
+    pub backend: BackendKind,
+    pub postgres: Option<PostgresSettings>,
+    pub vector: VectorSettings,
+}
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BackendKind {
+    #[default]
+    Sqlite,
+    Pgvector,
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresSettings {
+    pub url_env: Option<String>,
+    pub url: Option<String>,
+    pub schema: String,
+    #[serde(default = "connect_timeout")]
+    pub connect_timeout_seconds: u64,
+    #[serde(default = "statement_timeout")]
+    pub statement_timeout_ms: u64,
+}
+impl std::fmt::Debug for PostgresSettings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresSettings")
+            .field("url_env", &self.url_env)
+            .field("url", &self.url.as_ref().map(|_| "[REDACTED]"))
+            .field("schema", &self.schema)
+            .field("connect_timeout_seconds", &self.connect_timeout_seconds)
+            .field("statement_timeout_ms", &self.statement_timeout_ms)
+            .finish()
+    }
+}
+impl PostgresSettings {
+    pub fn validate_connection_source(&self) -> Result<()> {
+        match (&self.url, &self.url_env) {
+            (Some(url), None) if !url.trim().is_empty() => Ok(()),
+            (None, Some(name))
+                if !name.is_empty()
+                    && name.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_') =>
+            {
+                Ok(())
+            }
+            (Some(_), Some(_)) => Err(HypatiaError::Config(
+                "postgres.url and postgres.url_env are mutually exclusive; configure exactly one"
+                    .into(),
+            )),
+            (Some(_), None) => Err(HypatiaError::Config(
+                "postgres.url must be a nonempty connection string".into(),
+            )),
+            (None, Some(_)) => Err(HypatiaError::Config(
+                "postgres.url_env must name an environment variable".into(),
+            )),
+            (None, None) => Err(HypatiaError::Config(
+                "PostgreSQL requires exactly one of postgres.url or postgres.url_env".into(),
+            )),
+        }
+    }
+    /// Resolve only at connection time; never include a connection string in errors.
+    pub fn connection_url(&self) -> Result<String> {
+        self.validate_connection_source()?;
+        if let Some(url) = &self.url {
+            return Ok(url.clone());
+        }
+        let name = self.url_env.as_ref().expect("validated connection source");
+        std::env::var(name)
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .ok_or_else(|| {
+                HypatiaError::Config(
+                    "PostgreSQL URL environment variable is missing, empty or invalid".into(),
+                )
+            })
+    }
+}
+fn connect_timeout() -> u64 {
+    5
+}
+fn statement_timeout() -> u64 {
+    30000
+}
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct VectorSettings {
+    pub index: String,
+    pub metric: String,
+}
+impl Default for VectorSettings {
+    fn default() -> Self {
+        Self {
+            index: "hnsw".into(),
+            metric: "cosine".into(),
+        }
+    }
+}
+#[derive(Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+struct SettingsToml {
+    storage: StorageSettings,
+    embedding: EmbeddingToml,
+}
+impl ShelfSettings {
+    pub fn load(dir: &Path) -> Result<Self> {
+        let path = dir.join("shelf.toml");
+        let text = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => {
+                return Err(HypatiaError::Config(format!(
+                    "cannot read {}: {e}",
+                    path.display()
+                )));
+            }
+        };
+        Self::parse(&text, dir)
+    }
+    pub fn parse(text: &str, dir: &Path) -> Result<Self> {
+        // Do not echo TOML source, which might contain a mistakenly pasted secret.
+        let parsed: SettingsToml = toml::from_str(text)
+            .map_err(|e| HypatiaError::Config(format!("invalid shelf.toml: {}", e.message())))?;
+        if !matches!(parsed.embedding.provider.as_str(), "local" | "remote") {
+            return Err(HypatiaError::Config(
+                "embedding.provider must be local or remote".into(),
+            ));
+        }
+        let embedding = EmbeddingConfig::from_parsed(parsed.embedding, dir);
+        let settings = Self {
+            storage: parsed.storage,
+            embedding,
+        };
+        settings.validate()?;
+        Ok(settings)
+    }
+    pub fn validate(&self) -> Result<()> {
+        let fail = |s: &str| Err(HypatiaError::Config(s.into()));
+        if self.embedding.dimensions() == 0 {
+            return fail("embedding.dimensions must be positive");
+        }
+        if self.storage.vector.metric != "cosine" {
+            return fail("storage.vector.metric must be cosine");
+        }
+        if !matches!(self.storage.vector.index.as_str(), "hnsw" | "none") {
+            return fail("storage.vector.index must be hnsw or none");
+        }
+        if self.storage.backend == BackendKind::Pgvector {
+            if !self.embedding.model_identity_trusted {
+                return fail(
+                    "pgvector requires an explicit embedding.model (or readable local model and tokenizer files) to identify the vector space; model inference may remain unavailable",
+                );
+            }
+            let pg = self.storage.postgres.as_ref().ok_or_else(|| {
+                HypatiaError::Config(
+                    "pgvector requires [storage.postgres] with schema and exactly one of url or url_env".into(),
+                )
+            })?;
+            validate_schema(&pg.schema)?;
+            pg.validate_connection_source()?;
+            if pg.connect_timeout_seconds == 0
+                || pg.statement_timeout_ms == 0
+                || pg.statement_timeout_ms > i32::MAX as u64
+            {
+                return fail(
+                    "PostgreSQL timeouts must be positive; statement_timeout_ms must fit int32",
+                );
+            }
+            if self.embedding.dimensions() > 16000 {
+                return fail("pgvector vector dimensions must not exceed 16000");
+            }
+            if self.storage.vector.index == "hnsw" && self.embedding.dimensions() > 2000 {
+                return fail(
+                    "vector HNSW supports at most 2000 dimensions; explicitly choose index = 'none' for exact search",
+                );
+            }
+        } else if self.storage.postgres.is_some() {
+            return fail("storage.postgres requires backend = 'pgvector'");
+        }
+        Ok(())
+    }
+}
+pub fn validate_schema(schema: &str) -> Result<()> {
+    if schema.is_empty()
+        || schema.len() > 63
+        || !schema
+            .bytes()
+            .next()
+            .is_some_and(|b| b.is_ascii_alphabetic() || b == b'_')
+        || !schema
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+        || schema.starts_with("pg_")
+        || matches!(schema, "public" | "information_schema")
+    {
+        return Err(HypatiaError::Config("postgres.schema must be a dedicated 1–63 byte ASCII identifier, excluding public, information_schema and pg_*".into()));
+    }
+    Ok(())
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn strict_config_and_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            ShelfSettings::load(dir.path()).unwrap().storage.backend,
+            BackendKind::Sqlite
+        );
+        for text in [
+            "[storage]\nbackend='typo'",
+            "[storage]\nbacked='pgvector'",
+            "[storage]\nbackend='pgvector'",
+            "[storag]",
+            "[storage",
+            "[embedding]\nprovider='typo'",
+        ] {
+            assert!(ShelfSettings::parse(text, dir.path()).is_err(), "{text}");
+        }
+    }
+    #[test]
+    fn connection_sources_and_redaction() {
+        let dir = tempfile::tempdir().unwrap();
+        let parse = |connection: &str| {
+            ShelfSettings::parse(
+                &format!(
+                    "[embedding]\nmodel='test-model'\n[storage]\nbackend='pgvector'\n[storage.postgres]\nschema='test_schema'\n{connection}"
+                ),
+                dir.path(),
+            )
+        };
+        let url = "postgres://user:secret-test-password@localhost/db";
+        let settings = parse(&format!("url='{url}'")).unwrap();
+        let pg = settings.storage.postgres.as_ref().unwrap();
+        assert_eq!(pg.connection_url().unwrap(), url);
+        assert!(pg.url_env.is_none());
+        let debug = format!("{settings:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("secret-test-password"));
+        assert!(!debug.contains(url));
+        let env = parse("url_env='HYPATIA_TEST_MISSING_URL_9455722'").unwrap();
+        assert!(env.storage.postgres.unwrap().connection_url().is_err());
+        for source in [
+            "".to_string(),
+            "url=''".into(),
+            "url='   '".into(),
+            "url_env=''".into(),
+            "url_env='invalid-name'".into(),
+            format!("url='{url}'\nurl_env='HYPATIA_POSTGRES_URL'"),
+            format!("url='{url}'\nurl_env=''"),
+            "url=''\nurl_env='HYPATIA_POSTGRES_URL'".into(),
+        ] {
+            let error = parse(&source).unwrap_err().to_string();
+            assert!(!error.contains(url));
+            assert!(!error.contains("secret-test-password"));
+        }
+    }
+    #[test]
+    fn validates_schema_names() {
+        for s in ["", "public", "pg_catalog", "x;drop schema y", "a.b", "a-b"] {
+            assert!(validate_schema(s).is_err());
+        }
+        assert!(validate_schema("team_memory").is_ok());
+    }
+}

--- a/src/storage/shelf_manager.rs
+++ b/src/storage/shelf_manager.rs
@@ -1,46 +1,28 @@
+use crate::embedding::{EmbeddingProvider, build_provider};
+use crate::error::{HypatiaError, Result};
+use crate::model::{Content, QueryResult, QueryTarget, SearchOpts, ShelfConfig, ShelfId};
+use crate::storage::{ShelfRegistry, Storage, backend::ShelfBackend, settings::ShelfSettings};
 use std::collections::HashMap;
 use std::path::Path;
-
-use crate::embedding::{EmbeddingConfig, EmbeddingProvider, build_provider};
-use crate::error::{HypatiaError, Result};
-use crate::model::{QueryResult, QueryTarget, SearchOpts, ShelfConfig, ShelfId};
-use crate::storage::vector_index::VectorFileIndex;
-use crate::storage::{ShelfRegistry, SqliteStore, Storage, open_or_migrate};
 
 pub struct OpenShelf {
     pub id: ShelfId,
     pub config: ShelfConfig,
-    pub store: SqliteStore,
+    pub settings: ShelfSettings,
+    pub backend: ShelfBackend,
     pub embedder: Box<dyn EmbeddingProvider>,
-    /// ANN indexes per catalog (`vectors/<catalog>.usearch`). Rebuildable
-    /// cache — see plan §4; `None` when the catalog has no embeddings.
-    pub vectors: VectorIndexes,
 }
-
-/// Per-catalog ANN index handles.
-pub struct VectorIndexes {
-    pub dims: usize,
-    pub knowledge: Option<VectorFileIndex>,
-    pub statement: Option<VectorFileIndex>,
-}
-
-impl VectorIndexes {
-    pub fn get(&self, catalog: &str) -> Option<&VectorFileIndex> {
-        match catalog {
-            "statement" => self.statement.as_ref(),
-            _ => self.knowledge.as_ref(),
-        }
-    }
-
-    pub fn get_mut(&mut self, catalog: &str) -> Option<&mut VectorFileIndex> {
-        match catalog {
-            "statement" => self.statement.as_mut(),
-            _ => self.knowledge.as_mut(),
-        }
-    }
-}
-
 impl Storage for OpenShelf {
+    fn sql_dialect(&self) -> crate::engine::SqlDialect {
+        if self.backend.is_local() {
+            crate::engine::SqlDialect::Sqlite
+        } else {
+            crate::engine::SqlDialect::Postgres
+        }
+    }
+    fn sql_schema(&self) -> Option<&str> {
+        self.backend.schema()
+    }
     fn execute_query(
         &self,
         target: QueryTarget,
@@ -48,231 +30,126 @@ impl Storage for OpenShelf {
         params: Vec<serde_json::Value>,
     ) -> Result<QueryResult> {
         let rows = match target {
-            QueryTarget::Knowledge => {
-                let knowledge = self.store.query_knowledge(sql, params)?;
-                knowledge.into_iter().map(|k| knowledge_to_row(&k)).collect()
-            }
-            QueryTarget::Statement => {
-                let statements = self.store.query_statements(sql, params)?;
-                statements.into_iter().map(|s| statement_to_row(&s)).collect()
-            }
+            QueryTarget::Knowledge => self
+                .backend
+                .query_knowledge(sql, params)?
+                .iter()
+                .map(knowledge_to_row)
+                .collect(),
+            QueryTarget::Statement => self
+                .backend
+                .query_statements(sql, params)?
+                .iter()
+                .map(statement_to_row)
+                .collect(),
         };
         Ok(QueryResult::new(rows))
     }
-
     fn execute_search(&self, query: &str, opts: &SearchOpts) -> Result<QueryResult> {
-        let results = self.store.search(query, opts)?;
-        let rows = results
+        let rows = self
+            .backend
+            .search(query, opts)?
             .into_iter()
             .map(|r| {
-                let mut map = serde_json::Map::new();
-                map.insert("id".to_string(), serde_json::Value::Number(r.id.into()));
-                map.insert("catalog".to_string(), serde_json::Value::String(r.catalog));
-                map.insert("key".to_string(), serde_json::Value::String(r.key));
-                map.insert("content".to_string(), serde_json::Value::String(r.content));
-                map.insert(
-                    "rank".to_string(),
-                    serde_json::Value::Number(
-                        serde_json::Number::from_f64(r.rank)
-                            .unwrap_or(serde_json::Number::from(0)),
-                    ),
-                );
-                map
+                let mut m = serde_json::Map::new();
+                m.insert("id".into(), serde_json::json!(r.id));
+                m.insert("catalog".into(), serde_json::json!(r.catalog));
+                m.insert("key".into(), serde_json::json!(r.key));
+                m.insert("content".into(), serde_json::json!(r.content));
+                m.insert("rank".into(), serde_json::json!(r.rank));
+                m
             })
             .collect();
         Ok(QueryResult::new(rows))
     }
-
     fn execute_similar(
         &self,
         query_text: &str,
         opts: &SearchOpts,
         target: QueryTarget,
     ) -> Result<QueryResult> {
-        let query_vector = self.embedder.embed(query_text)?;
-        let catalog = match target {
-            QueryTarget::Knowledge => "knowledge",
-            QueryTarget::Statement => "statement",
-        };
-
-        // ANN path (usearch cache) — preferred when an index is available.
-        if let Some(idx) = self.vectors.get(catalog) {
-            if let Ok(hits) = idx.search(&query_vector, opts.limit as usize) {
-                if !hits.is_empty() {
-                    let ids: Vec<i64> = hits.iter().map(|(id, _)| *id).collect();
-                    let dist: HashMap<i64, f64> =
-                        hits.iter().map(|(id, d)| (*id, *d)).collect();
-                    let rows_raw = self.store.rows_by_doc_ids(catalog, &ids)?;
-                    let by_id: std::collections::HashMap<i64, (String, String)> = rows_raw
-                        .into_iter()
-                        .map(|(id, k, c)| (id, (k.clone(), c)))
-                        .collect();
-                    let key_field = match target {
-                        QueryTarget::Knowledge => "name",
-                        QueryTarget::Statement => "triple",
-                    };
-                    let mut rows: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
-                    for (id, distance) in &hits {
-                        let Some((key, content)) = by_id.get(id) else { continue };
-                        let mut map = serde_json::Map::new();
-                        map.insert(key_field.to_string(), serde_json::Value::String(key.clone()));
-                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(content) {
-                            map.insert("content".to_string(), parsed);
-                        }
-                        map.insert(
-                            "distance".to_string(),
-                            serde_json::Value::Number(
-                                serde_json::Number::from_f64(*distance)
-                                    .unwrap_or(serde_json::Number::from(0)),
-                            ),
-                        );
-                        rows.push(map);
-                    }
-                    return Ok(QueryResult::new(rows));
-                }
-            }
-        }
-
-        // Fallback: Rust brute-force kNN over embedding BLOBs.
-        let rows = match target {
-            QueryTarget::Knowledge => {
-                let results = self.store.vector_search_knowledge(&query_vector, opts.limit)?;
-                results.into_iter().map(|(name, content, distance)| {
-                    let mut map = serde_json::Map::new();
-                    map.insert("name".to_string(), serde_json::Value::String(name));
-                    map.insert("content".to_string(), serde_json::Value::String(content));
-                    map.insert(
-                        "distance".to_string(),
-                        serde_json::Value::Number(
-                            serde_json::Number::from_f64(distance)
-                                .unwrap_or(serde_json::Number::from(0)),
-                        ),
-                    );
-                    map
-                }).collect()
-            }
-            QueryTarget::Statement => {
-                let results = self.store.vector_search_statements(&query_vector, opts.limit)?;
-                results.into_iter().map(|(triple, content, distance)| {
-                    let mut map = serde_json::Map::new();
-                    map.insert("triple".to_string(), serde_json::Value::String(triple));
-                    map.insert("content".to_string(), serde_json::Value::String(content));
-                    map.insert(
-                        "distance".to_string(),
-                        serde_json::Value::Number(
-                            serde_json::Number::from_f64(distance)
-                                .unwrap_or(serde_json::Number::from(0)),
-                        ),
-                    );
-                    map
-                }).collect()
-            }
-        };
-        Ok(QueryResult::new(rows))
-    }
-
-    fn execute_khop(
-        &self,
-        head: &str,
-        relation: Option<&str>,
-        depth: i64,
-    ) -> Result<QueryResult> {
-        let statements = self.store.query_khop(head, relation, depth)?;
-        let rows = statements.into_iter().map(|s| statement_to_row(&s)).collect();
-        Ok(QueryResult::new(rows))
-    }
-}
-
-impl OpenShelf {
-    fn open_vector_indexes(&mut self, dims: usize) -> Result<()> {
-        for catalog in ["knowledge", "statement"] {
-            let path = self.config.vectors_path.join(format!("{catalog}.usearch"));
-            let idx = Self::open_vector_index(&self.store, &path, catalog, dims)?;
-            match catalog {
-                "statement" => self.vectors.statement = idx,
-                _ => self.vectors.knowledge = idx,
-            }
-        }
-        Ok(())
-    }
-
-    fn open_vector_index(
-        store: &SqliteStore,
-        path: &Path,
-        catalog: &str,
-        dims: usize,
-    ) -> Result<Option<VectorFileIndex>> {
-        let pairs = store.embedding_pairs(catalog)?;
-        let items: Vec<(i64, Vec<f32>)> = pairs
+        let vector = self.embedder.embed(query_text)?;
+        let rows = self
+            .backend
+            .vector_search(target, &vector, opts.limit)?
             .into_iter()
-            .map(|(id, blob)| (id, crate::storage::sqlite_store::blob_to_vector(&blob)))
-            .filter(|(_, v)| v.len() == dims)
+            .map(|(key, content, distance)| {
+                let mut m = serde_json::Map::new();
+                m.insert(target.key_column().into(), serde_json::json!(key));
+                // One shape for ANN, exact local search, and PostgreSQL.
+                m.insert(
+                    "content".into(),
+                    serde_json::from_str(&content).unwrap_or(serde_json::Value::Null),
+                );
+                m.insert("distance".into(), serde_json::json!(distance));
+                m
+            })
             .collect();
-        if items.is_empty() {
-            return Ok(None);
-        }
-        if VectorFileIndex::exists(path) {
-            if let Ok(idx) = VectorFileIndex::load(path, dims) {
-                // Reconcile against the authoritative BLOB rows.
-                if idx.size() == items.len() {
-                    return Ok(Some(idx));
-                }
-            }
-        }
-        VectorFileIndex::build(path, dims, &items).map(Some)
+        Ok(QueryResult::new(rows))
     }
-
-    /// Push one embedding into the ANN index (doc_id resolved from docs).
-    pub fn vector_upsert(&mut self, catalog: &str, key: &str, vector: &[f32]) -> Result<()> {
-        let Some(idx) = self.vectors.get_mut(catalog) else {
-            return Ok(());
-        };
-        if let Some(doc_id) = self.store.doc_id_by_key(catalog, key)? {
-            idx.upsert(doc_id, vector)?;
-        }
-        Ok(())
-    }
-
-    /// Remove one vector from the ANN index.
-    pub fn vector_remove(&mut self, catalog: &str, key: &str) -> Result<()> {
-        let Some(idx) = self.vectors.get_mut(catalog) else {
-            return Ok(());
-        };
-        if let Some(doc_id) = self.store.doc_id_by_key(catalog, key)? {
-            idx.remove(doc_id)?;
-        }
-        Ok(())
-    }
-
-    /// Persist dirty ANN snapshots (atomic rename).
-    pub fn save_vector_indexes(&mut self) -> Result<()> {
-        for idx in [&mut self.vectors.knowledge, &mut self.vectors.statement] {
-            if let Some(idx) = idx {
-                idx.save()?;
-            }
-        }
-        Ok(())
-    }
-
-    /// Rebuild both ANN indexes from the authoritative embedding BLOBs and save.
-    pub fn rebuild_vector_indexes(&mut self) -> Result<()> {
-        let dims = self.vectors.dims;
-        self.open_vector_indexes(dims)?;
-        self.save_vector_indexes()
+    fn execute_khop(&self, head: &str, relation: Option<&str>, depth: i64) -> Result<QueryResult> {
+        Ok(QueryResult::new(
+            self.backend
+                .query_khop(head, relation, depth)?
+                .iter()
+                .map(statement_to_row)
+                .collect(),
+        ))
     }
 }
-
-impl Drop for OpenShelf {
-    fn drop(&mut self) {
-        // Best-effort snapshot on process exit; a lost snapshot is repaired
-        // by the count-reconcile on next open.
-        let _ = self.save_vector_indexes();
+impl OpenShelf {
+    pub fn open(path: &Path, name: Option<&str>) -> Result<Self> {
+        // Configuration errors must not create a SQLite file or local vector directory.
+        let settings = ShelfSettings::load(path)?;
+        let config = ShelfConfig::from_path(path, name);
+        std::fs::create_dir_all(path)?;
+        let backend = ShelfBackend::open(&config, &settings)?;
+        std::fs::create_dir_all(&config.archives_path)?;
+        let embedder = build_provider(&settings.embedding);
+        Ok(Self {
+            id: config.id.clone(),
+            config,
+            settings,
+            backend,
+            embedder,
+        })
+    }
+    /// Content has committed. Embedding failures leave the row pending for backfill.
+    pub fn embed_saved(&mut self, catalog: &str, key: &str, content: &Content, version: i64) {
+        let outcome = (|| -> Result<bool> {
+            let Some(v) = self.embedder.maybe_embed(&content.embedding_text(key))? else {
+                return Ok(false);
+            };
+            self.backend.install_embedding(catalog, key, version, &v)
+        })();
+        match outcome {
+            Ok(true) => {}
+            Ok(false) => eprintln!(
+                "warning: {catalog}/{key}: content saved; embedding pending (model unavailable or content changed); run backfill"
+            ),
+            Err(e) => eprintln!(
+                "warning: {catalog}/{key}: content saved; embedding pending: {e}; run backfill"
+            ),
+        }
+    }
+    pub fn save_vector_indexes(&mut self) -> Result<()> {
+        self.backend.flush()
+    }
+    pub fn rebuild_vector_indexes(&mut self) -> Result<()> {
+        if self.backend.is_local() {
+            self.backend.rebuild_indexes()
+        } else {
+            self.backend.flush()
+        }
     }
 }
 
 fn knowledge_to_row(k: &crate::model::Knowledge) -> serde_json::Map<String, serde_json::Value> {
     let mut map = serde_json::Map::new();
-    map.insert("name".to_string(), serde_json::Value::String(k.name.clone()));
+    map.insert(
+        "name".to_string(),
+        serde_json::Value::String(k.name.clone()),
+    );
     map.insert(
         "content".to_string(),
         serde_json::to_value(&k.content).unwrap_or(serde_json::Value::Null),
@@ -286,10 +163,22 @@ fn knowledge_to_row(k: &crate::model::Knowledge) -> serde_json::Map<String, serd
 
 fn statement_to_row(s: &crate::model::Statement) -> serde_json::Map<String, serde_json::Value> {
     let mut map = serde_json::Map::new();
-    map.insert("triple".to_string(), serde_json::Value::String(s.key.to_csv_key()));
-    map.insert("head".to_string(), serde_json::Value::String(s.key.head.clone()));
-    map.insert("relation".to_string(), serde_json::Value::String(s.key.relation.clone()));
-    map.insert("tail".to_string(), serde_json::Value::String(s.key.tail.clone()));
+    map.insert(
+        "triple".to_string(),
+        serde_json::Value::String(s.key.to_csv_key()),
+    );
+    map.insert(
+        "head".to_string(),
+        serde_json::Value::String(s.key.head.clone()),
+    );
+    map.insert(
+        "relation".to_string(),
+        serde_json::Value::String(s.key.relation.clone()),
+    );
+    map.insert(
+        "tail".to_string(),
+        serde_json::Value::String(s.key.tail.clone()),
+    );
     map.insert(
         "content".to_string(),
         serde_json::to_value(&s.content).unwrap_or(serde_json::Value::Null),
@@ -299,10 +188,16 @@ fn statement_to_row(s: &crate::model::Statement) -> serde_json::Map<String, serd
         serde_json::Value::String(s.created_at.to_string()),
     );
     if let Some(ts) = s.tr_start {
-        map.insert("tr_start".to_string(), serde_json::Value::String(ts.to_string()));
+        map.insert(
+            "tr_start".to_string(),
+            serde_json::Value::String(ts.to_string()),
+        );
     }
     if let Some(te) = s.tr_end {
-        map.insert("tr_end".to_string(), serde_json::Value::String(te.to_string()));
+        map.insert(
+            "tr_end".to_string(),
+            serde_json::Value::String(te.to_string()),
+        );
     }
     map
 }
@@ -368,42 +263,14 @@ impl ShelfManager {
 
     /// Internal connect logic without registry persistence.
     fn connect_internal(&mut self, path: &Path, name: Option<&str>) -> Result<String> {
-        // Ensure directory exists
-        std::fs::create_dir_all(path)?;
-
         let config = ShelfConfig::from_path(path, name);
-
-        // Ensure archives/ and vectors/ directories exist
-        std::fs::create_dir_all(&config.archives_path)?;
-        std::fs::create_dir_all(&config.vectors_path)?;
         let shelf_name = config.id.name.clone();
-
-        // Check if already connected
         if self.shelves.contains_key(&shelf_name) {
             return Err(HypatiaError::Shelf(format!(
-                "shelf '{}' is already connected",
-                shelf_name
+                "shelf '{shelf_name}' is already connected"
             )));
         }
-
-        let embedding_config = EmbeddingConfig::from_shelf_dir(path);
-        // Migrates legacy duckdb+sqlite shelves transparently on open.
-        let store = open_or_migrate(&config)?;
-
-        let embedder = build_provider(&embedding_config);
-
-        let mut shelf = OpenShelf {
-            id: config.id.clone(),
-            config: config.clone(),
-            store,
-            embedder,
-            vectors: VectorIndexes {
-                dims: embedding_config.dimensions(),
-                knowledge: None,
-                statement: None,
-            },
-        };
-        shelf.open_vector_indexes(embedding_config.dimensions())?;
+        let shelf = OpenShelf::open(path, name)?;
 
         self.shelves.insert(shelf_name.clone(), shelf);
         Ok(shelf_name)
@@ -445,23 +312,121 @@ impl ShelfManager {
             .get(name)
             .ok_or_else(|| HypatiaError::Shelf(format!("shelf '{name}' is not connected")))?;
 
-        std::fs::create_dir_all(dest)?;
-
-        // Copy the unified SQLite database.
-        std::fs::copy(&shelf.config.sqlite_path, dest.join("hypatia.sqlite"))?;
-
-        // Copy vectors/ (rebuildable cache, but ships with the export).
-        let vectors_dest = dest.join("vectors");
-        if shelf.config.vectors_path.exists() {
-            copy_dir_recursive(&shelf.config.vectors_path, &vectors_dest)?;
+        if dest.exists() && std::fs::read_dir(dest)?.next().is_some() {
+            return Err(HypatiaError::Validation(
+                "export destination must be empty".into(),
+            ));
         }
-
-        // Copy archives/ directory if it exists and has content
-        let archives_dest = dest.join("archives");
+        let parent = dest
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        std::fs::create_dir_all(parent)?;
+        let source = shelf
+            .config
+            .archives_path
+            .parent()
+            .unwrap()
+            .canonicalize()?;
+        if parent.canonicalize()?.starts_with(&source) {
+            return Err(HypatiaError::Validation(
+                "export destination must be outside source shelf".into(),
+            ));
+        }
+        let stage = tempfile::Builder::new()
+            .prefix(".hypatia-export-")
+            .tempdir_in(parent)?;
+        // Both local formats describe exactly the same WAL-safe snapshot.
+        let snapshot = if shelf.backend.is_local() {
+            let db = stage.path().join("hypatia.sqlite");
+            shelf.backend.backup_local(&db)?;
+            super::SqliteStore::open(&db)?.snapshot()?
+        } else {
+            shelf.backend.snapshot()?
+        };
+        snapshot.validate()?;
+        let mut writer =
+            std::io::BufWriter::new(std::fs::File::create(stage.path().join("snapshot.json"))?);
+        serde_json::to_writer_pretty(&mut writer, &snapshot)?;
+        std::io::Write::flush(&mut writer)?;
+        drop(writer);
         if shelf.config.archives_path.exists() {
-            copy_dir_recursive(&shelf.config.archives_path, &archives_dest)?;
+            copy_dir_recursive(&shelf.config.archives_path, &stage.path().join("archives"))?;
         }
+        super::transfer::validate_archives(&snapshot, &stage.path().join("archives"))?;
+        super::transfer::write_manifest(stage.path(), &snapshot)?;
+        // Publishing a completed package is one rename; failures leave no partial export.
+        if dest.exists() {
+            std::fs::remove_dir(dest)?;
+        }
+        std::fs::rename(stage.path(), dest)?;
+        Ok(())
+    }
 
+    /// Import logical data into an already configured, empty target. Never switches config.
+    pub fn import(&mut self, name: &str, source: &Path, reembed: bool) -> Result<()> {
+        let shelf = self
+            .shelves
+            .get_mut(name)
+            .ok_or_else(|| HypatiaError::Shelf(format!("shelf '{name}' is not connected")))?;
+        let logical = source.join("snapshot.json");
+        let snapshot = if logical.exists() {
+            let snapshot = serde_json::from_reader::<_, super::transfer::Snapshot>(
+                std::io::BufReader::new(std::fs::File::open(logical)?),
+            )?;
+            super::transfer::verify_manifest(source, &snapshot)?;
+            snapshot
+        } else {
+            // Read a legacy export through a temporary backup, so opening/migrating
+            // its schema cannot modify the user's source export.
+            let db = source.join("hypatia.sqlite");
+            if !db.is_file() {
+                return Err(HypatiaError::Validation(
+                    "source must contain snapshot.json or hypatia.sqlite".into(),
+                ));
+            }
+            let temporary = tempfile::tempdir()?;
+            let database = temporary.path().join("hypatia.sqlite");
+            let legacy = rusqlite::Connection::open_with_flags(
+                &db,
+                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+            )?;
+            legacy.backup("main", &database, None)?;
+            super::SqliteStore::open(&database)?.snapshot()?
+        };
+        let snapshot = if reembed {
+            snapshot.without_embeddings()
+        } else {
+            snapshot
+        };
+        snapshot.validate()?;
+        // Check source attachment references before committing any imported records.
+        super::transfer::validate_archives(&snapshot, &source.join("archives"))?;
+        let source_archives = source.join("archives");
+        if source_archives.exists() {
+            // Copy first: a filesystem failure cannot leave imported references broken.
+            // Any copied files on database failure remain safe and reusable on retry.
+            copy_dir_recursive(&source_archives, &shelf.config.archives_path)?;
+        }
+        shelf.backend.import_snapshot(&snapshot)?;
+        shelf.backend.rebuild_indexes()?;
+        let mut restored = shelf.backend.snapshot()?;
+        let mut expected = snapshot.clone();
+        restored
+            .knowledge
+            .sort_by(|a, b| a.knowledge.name.cmp(&b.knowledge.name));
+        expected
+            .knowledge
+            .sort_by(|a, b| a.knowledge.name.cmp(&b.knowledge.name));
+        restored
+            .statements
+            .sort_by_key(|r| r.statement.key.to_csv_key());
+        expected
+            .statements
+            .sort_by_key(|r| r.statement.key.to_csv_key());
+        if restored.knowledge != expected.knowledge || restored.statements != expected.statements {
+            return Err(HypatiaError::Validation("data imported but verification differed; preserve source and inspect target before switching".into()));
+        }
         Ok(())
     }
 
@@ -498,6 +463,11 @@ fn dirs_home() -> std::path::PathBuf {
 
 /// Recursively copy a directory tree.
 fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
+    if std::fs::symlink_metadata(dest).is_ok_and(|m| m.file_type().is_symlink()) {
+        return Err(HypatiaError::Validation(
+            "archive destination cannot be a symlink".into(),
+        ));
+    }
     if !src.exists() {
         return Ok(());
     }
@@ -505,11 +475,30 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
         let src_path = entry.path();
+        if entry.file_type()?.is_symlink() {
+            return Err(HypatiaError::Validation(
+                "archive copy does not follow symlinks".into(),
+            ));
+        }
         let dest_path = dest.join(entry.file_name());
+        if std::fs::symlink_metadata(&dest_path).is_ok_and(|m| m.file_type().is_symlink()) {
+            return Err(HypatiaError::Validation(
+                "archive destination cannot be a symlink".into(),
+            ));
+        }
         if src_path.is_dir() {
             copy_dir_recursive(&src_path, &dest_path)?;
         } else {
-            std::fs::copy(&src_path, &dest_path)?;
+            if dest_path.exists() {
+                if std::fs::read(&src_path)? != std::fs::read(&dest_path)? {
+                    return Err(HypatiaError::Validation(format!(
+                        "archive destination already contains different content: {}",
+                        dest_path.display()
+                    )));
+                }
+            } else {
+                std::fs::copy(&src_path, &dest_path)?;
+            }
         }
     }
     Ok(())
@@ -574,7 +563,7 @@ mod tests {
         // Add some data
         let shelf = mgr.get("export-test").unwrap();
         shelf
-            .store
+            .backend
             .insert_knowledge("test", &Content::new("data"))
             .unwrap();
 
@@ -618,7 +607,10 @@ mod tests {
         mgr.connect(dir.path(), Some("status-test")).unwrap();
 
         let shelves = mgr.list();
-        let entry = shelves.iter().find(|(n, _, _)| *n == "status-test").unwrap();
+        let entry = shelves
+            .iter()
+            .find(|(n, _, _)| *n == "status-test")
+            .unwrap();
         assert!(entry.2); // is_connected = true
     }
 }

--- a/src/storage/shelf_registry.rs
+++ b/src/storage/shelf_registry.rs
@@ -96,7 +96,10 @@ mod tests {
         let loaded = ShelfRegistry::load(&path).unwrap();
         assert_eq!(loaded.shelves.len(), 2);
         assert_eq!(loaded.get("default"), Some(&PathBuf::from("/tmp/default")));
-        assert_eq!(loaded.get("project-a"), Some(&PathBuf::from("/tmp/project-a")));
+        assert_eq!(
+            loaded.get("project-a"),
+            Some(&PathBuf::from("/tmp/project-a"))
+        );
     }
 
     #[test]

--- a/src/storage/sqlite_store.rs
+++ b/src/storage/sqlite_store.rs
@@ -10,13 +10,13 @@
 use std::path::Path;
 
 use chrono::NaiveDateTime;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::error::{HypatiaError, Result, StorageError};
-use crate::storage::json_index::{json_contains_str, rebuild_all, replace_postings_in};
 use crate::model::{Content, Knowledge, SearchOpts, Statement, StatementKey};
+use crate::storage::json_index::{json_contains_str, rebuild_all, replace_postings_in};
 
-const SCHEMA_VERSION: &str = "2";
+const SCHEMA_VERSION: &str = "3";
 
 const META_SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS meta(
@@ -102,14 +102,7 @@ END;
 /// BM25 column weights: fts_key=10, fts_data=1, fts_tags=5, fts_synonyms=3
 const BM25_WEIGHTS: &str = "bm25(docs_fts, 10.0, 1.0, 5.0, 3.0)";
 
-#[derive(Debug, Clone)]
-pub struct FtsResult {
-    pub id: i64,
-    pub catalog: String,
-    pub key: String,
-    pub content: String,
-    pub rank: f64,
-}
+pub use super::FtsResult;
 
 /// Structured document for FTS indexing with multi-column support.
 pub struct FtsDoc {
@@ -129,7 +122,11 @@ pub struct SqliteStore {
 pub fn vector_to_blob(v: &[f32]) -> Vec<u8> {
     v.iter()
         .flat_map(|f| {
-            let f = if f.is_nan() || f.is_infinite() { 0.0f32 } else { *f };
+            let f = if f.is_nan() || f.is_infinite() {
+                0.0f32
+            } else {
+                *f
+            };
             f.to_le_bytes()
         })
         .collect()
@@ -178,11 +175,9 @@ fn json_to_sql(v: &serde_json::Value) -> rusqlite::types::Value {
 
 fn parse_timestamp(s: &str) -> Result<NaiveDateTime> {
     NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f").map_err(|e| {
-        HypatiaError::Storage(StorageError::Sqlite(rusqlite::Error::FromSqlConversionFailure(
-            0,
-            rusqlite::types::Type::Text,
-            Box::new(e),
-        )))
+        HypatiaError::Storage(StorageError::Sqlite(
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e)),
+        ))
     })
 }
 
@@ -200,7 +195,11 @@ fn row_to_knowledge(row: &rusqlite::Row) -> rusqlite::Result<Knowledge> {
     let created_at = parse_timestamp(&created_at).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
     })?;
-    Ok(Knowledge { name, content, created_at })
+    Ok(Knowledge {
+        name,
+        content,
+        created_at,
+    })
 }
 
 fn row_to_statement(row: &rusqlite::Row) -> rusqlite::Result<Statement> {
@@ -222,12 +221,24 @@ fn row_to_statement(row: &rusqlite::Row) -> rusqlite::Result<Statement> {
     })?;
     let _ = triple; // PK; key derived from columns
     Ok(Statement {
-        key: StatementKey { head, relation, tail },
+        key: StatementKey {
+            head,
+            relation,
+            tail,
+        },
         content,
         created_at: parse(created_at)?,
         tr_start: tr_start.map(parse).transpose()?,
         tr_end: tr_end.map(parse).transpose()?,
     })
+}
+
+fn catalog_table(catalog: &str) -> Result<(&'static str, &'static str)> {
+    match catalog {
+        "knowledge" => Ok(("knowledge", "name")),
+        "statement" => Ok(("statement", "triple")),
+        _ => Err(HypatiaError::Validation("unknown catalog".into())),
+    }
 }
 
 impl SqliteStore {
@@ -244,19 +255,14 @@ impl SqliteStore {
     fn register_udfs(&self) -> Result<()> {
         use rusqlite::functions::FunctionFlags;
         self.conn
-            .create_scalar_function(
-                "json_contains",
-                2,
-                FunctionFlags::SQLITE_UTF8,
-                |ctx| {
-                    let lhs: Option<String> = ctx.get(0)?;
-                    let rhs: Option<String> = ctx.get(1)?;
-                    match (lhs, rhs) {
-                        (Some(l), Some(r)) => Ok(json_contains_str(&l, &r)),
-                        _ => Ok(false),
-                    }
-                },
-            )
+            .create_scalar_function("json_contains", 2, FunctionFlags::SQLITE_UTF8, |ctx| {
+                let lhs: Option<String> = ctx.get(0)?;
+                let rhs: Option<String> = ctx.get(1)?;
+                match (lhs, rhs) {
+                    (Some(l), Some(r)) => Ok(json_contains_str(&l, &r)),
+                    _ => Ok(false),
+                }
+            })
             .map_err(StorageError::from)?;
         Ok(())
     }
@@ -288,6 +294,27 @@ impl SqliteStore {
     }
 
     fn init_schema(&self) -> Result<()> {
+        let has_meta: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='meta')",
+            [],
+            |r| r.get(0),
+        )?;
+        if has_meta {
+            let version: Option<String> = self
+                .conn
+                .query_row("SELECT v FROM meta WHERE k='schema_version'", [], |r| {
+                    r.get(0)
+                })
+                .optional()?;
+            if version
+                .as_deref()
+                .is_some_and(|v| !matches!(v, "1" | "2" | "3"))
+            {
+                return Err(HypatiaError::Config(
+                    "unsupported SQLite schema version; use a compatible binary".into(),
+                ));
+            }
+        }
         self.conn.execute_batch(
             "PRAGMA journal_mode = WAL;
              PRAGMA synchronous = NORMAL;
@@ -306,12 +333,55 @@ impl SqliteStore {
                 r.get(0)
             })
             .optional()?;
+        if version
+            .as_deref()
+            .is_some_and(|v| !matches!(v, "1" | "2" | "3"))
+        {
+            return Err(HypatiaError::Config(
+                "unsupported SQLite schema version; use a compatible binary".into(),
+            ));
+        }
         if version.is_none() {
             self.conn.execute(
                 "INSERT INTO meta(k, v) VALUES('schema_version', ?1)",
                 params![SCHEMA_VERSION],
             )?;
         }
+        // A shelf-wide clock prevents stale writeback even after delete/recreate.
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "INSERT OR IGNORE INTO meta(k,v) VALUES('content_clock','0')",
+            [],
+        )?;
+        for (table, pk) in [("knowledge", "name"), ("statement", "triple")] {
+            let has_version: bool = tx.query_row(&format!("SELECT EXISTS(SELECT 1 FROM pragma_table_info('{table}') WHERE name='content_version')"), [], |r| r.get(0))?;
+            if !has_version {
+                tx.execute_batch(&format!(
+                    "ALTER TABLE {table} ADD COLUMN content_version INTEGER NOT NULL DEFAULT 0"
+                ))?;
+            }
+            tx.execute_batch(&format!("
+                CREATE TRIGGER IF NOT EXISTS {table}_version_insert AFTER INSERT ON {table} BEGIN
+                  UPDATE meta SET v=CAST(v AS INTEGER)+1 WHERE k='content_clock';
+                  UPDATE {table} SET content_version=(SELECT CAST(v AS INTEGER) FROM meta WHERE k='content_clock') WHERE {pk}=new.{pk};
+                END;
+                CREATE TRIGGER IF NOT EXISTS {table}_cache_delete AFTER DELETE ON {table} BEGIN
+                  UPDATE meta SET v=CAST(v AS INTEGER)+1 WHERE k='content_clock';
+                END;
+                CREATE TRIGGER IF NOT EXISTS {table}_cache_embedding AFTER UPDATE OF embedding ON {table} BEGIN
+                  UPDATE meta SET v=CAST(v AS INTEGER)+1 WHERE k='content_clock';
+                END;
+                CREATE TRIGGER IF NOT EXISTS {table}_version_update AFTER UPDATE OF content ON {table} BEGIN
+                  UPDATE meta SET v=CAST(v AS INTEGER)+1 WHERE k='content_clock';
+                  UPDATE {table} SET embedding=NULL, content_version=(SELECT CAST(v AS INTEGER) FROM meta WHERE k='content_clock') WHERE {pk}=new.{pk};
+                END;
+            "))?;
+        }
+        tx.execute(
+            "UPDATE meta SET v=?1 WHERE k='schema_version'",
+            [SCHEMA_VERSION],
+        )?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -335,13 +405,27 @@ impl SqliteStore {
             tx.execute(
                 "UPDATE docs SET fts_key=?1, fts_data=?2, fts_tags=?3, fts_synonyms=?4
                  WHERE catalog=?5 AND key=?6",
-                params![doc.fts_key, doc.fts_data, doc.fts_tags, doc.fts_synonyms, catalog, key],
+                params![
+                    doc.fts_key,
+                    doc.fts_data,
+                    doc.fts_tags,
+                    doc.fts_synonyms,
+                    catalog,
+                    key
+                ],
             )?;
         } else {
             tx.execute(
                 "INSERT INTO docs(catalog, key, fts_key, fts_data, fts_tags, fts_synonyms)
                  VALUES(?1, ?2, ?3, ?4, ?5, ?6)",
-                params![catalog, key, doc.fts_key, doc.fts_data, doc.fts_tags, doc.fts_synonyms],
+                params![
+                    catalog,
+                    key,
+                    doc.fts_key,
+                    doc.fts_data,
+                    doc.fts_tags,
+                    doc.fts_synonyms
+                ],
             )?;
         }
         let id: i64 = tx
@@ -361,7 +445,7 @@ impl SqliteStore {
 
     // ── Knowledge CRUD ───────────────────────────────────────────────
 
-    pub fn insert_knowledge(&self, name: &str, content: &Content) -> Result<()> {
+    pub fn insert_knowledge(&self, name: &str, content: &Content) -> Result<i64> {
         let json = content.to_json_string();
         let tx = self.conn.unchecked_transaction()?;
         tx.execute(
@@ -371,8 +455,13 @@ impl SqliteStore {
         .map_err(StorageError::from)?;
         let doc_id = self.docs_upsert_in(&tx, "knowledge", name, &fts_doc_for(content, name))?;
         replace_postings_in(&tx, doc_id, &json)?;
+        let version: i64 = tx.query_row(
+            "SELECT content_version FROM knowledge WHERE name=?1",
+            [&name],
+            |r| r.get(0),
+        )?;
         tx.commit()?;
-        Ok(())
+        Ok(version)
     }
 
     pub fn get_knowledge(&self, name: &str) -> Result<Option<Knowledge>> {
@@ -387,7 +476,7 @@ impl SqliteStore {
         Ok(result)
     }
 
-    pub fn update_knowledge(&self, name: &str, content: &Content) -> Result<()> {
+    pub fn update_knowledge(&self, name: &str, content: &Content) -> Result<i64> {
         let json = content.to_json_string();
         let tx = self.conn.unchecked_transaction()?;
         let rows = tx
@@ -404,8 +493,13 @@ impl SqliteStore {
         }
         let doc_id = self.docs_upsert_in(&tx, "knowledge", name, &fts_doc_for(content, name))?;
         replace_postings_in(&tx, doc_id, &json)?;
+        let version: i64 = tx.query_row(
+            "SELECT content_version FROM knowledge WHERE name=?1",
+            [&name],
+            |r| r.get(0),
+        )?;
         tx.commit()?;
-        Ok(())
+        Ok(version)
     }
 
     pub fn delete_knowledge(&self, name: &str) -> Result<()> {
@@ -436,7 +530,10 @@ impl SqliteStore {
         let sql_params: Vec<rusqlite::types::Value> = params.iter().map(json_to_sql).collect();
         let mut stmt = self.conn.prepare(sql).map_err(StorageError::from)?;
         let rows = stmt
-            .query_map(rusqlite::params_from_iter(sql_params.clone()), row_to_knowledge)
+            .query_map(
+                rusqlite::params_from_iter(sql_params.clone()),
+                row_to_knowledge,
+            )
             .map_err(StorageError::from)?;
         let mut result = Vec::new();
         for row in rows {
@@ -453,7 +550,7 @@ impl SqliteStore {
         content: &Content,
         tr_start: Option<NaiveDateTime>,
         tr_end: Option<NaiveDateTime>,
-    ) -> Result<()> {
+    ) -> Result<i64> {
         let json = content.to_json_string();
         let triple = key.to_csv_key();
         let tr_start_str = tr_start.as_ref().map(format_timestamp);
@@ -462,13 +559,27 @@ impl SqliteStore {
         tx.execute(
             "INSERT INTO statement (triple, head, relation, tail, content, tr_start, tr_end)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![triple, key.head, key.relation, key.tail, json, tr_start_str, tr_end_str],
+            params![
+                triple,
+                key.head,
+                key.relation,
+                key.tail,
+                json,
+                tr_start_str,
+                tr_end_str
+            ],
         )
         .map_err(StorageError::from)?;
-        let doc_id = self.docs_upsert_in(&tx, "statement", &triple, &fts_doc_for(content, &triple))?;
+        let doc_id =
+            self.docs_upsert_in(&tx, "statement", &triple, &fts_doc_for(content, &triple))?;
         replace_postings_in(&tx, doc_id, &json)?;
+        let version: i64 = tx.query_row(
+            "SELECT content_version FROM statement WHERE triple=?1",
+            [&triple],
+            |r| r.get(0),
+        )?;
         tx.commit()?;
-        Ok(())
+        Ok(version)
     }
 
     pub fn get_statement(&self, key: &StatementKey) -> Result<Option<Statement>> {
@@ -491,7 +602,7 @@ impl SqliteStore {
         content: &Content,
         tr_start: Option<NaiveDateTime>,
         tr_end: Option<NaiveDateTime>,
-    ) -> Result<()> {
+    ) -> Result<i64> {
         let json = content.to_json_string();
         let triple = key.to_csv_key();
         let tr_start_str = tr_start.as_ref().map(format_timestamp);
@@ -509,10 +620,16 @@ impl SqliteStore {
                 key: triple,
             });
         }
-        let doc_id = self.docs_upsert_in(&tx, "statement", &triple, &fts_doc_for(content, &triple))?;
+        let doc_id =
+            self.docs_upsert_in(&tx, "statement", &triple, &fts_doc_for(content, &triple))?;
         replace_postings_in(&tx, doc_id, &json)?;
+        let version: i64 = tx.query_row(
+            "SELECT content_version FROM statement WHERE triple=?1",
+            [&triple],
+            |r| r.get(0),
+        )?;
         tx.commit()?;
-        Ok(())
+        Ok(version)
     }
 
     pub fn delete_statement(&self, key: &StatementKey) -> Result<()> {
@@ -555,7 +672,10 @@ impl SqliteStore {
         let sql_params: Vec<rusqlite::types::Value> = params.iter().map(json_to_sql).collect();
         let mut stmt = self.conn.prepare(sql).map_err(StorageError::from)?;
         let rows = stmt
-            .query_map(rusqlite::params_from_iter(sql_params.clone()), row_to_statement)
+            .query_map(
+                rusqlite::params_from_iter(sql_params.clone()),
+                row_to_statement,
+            )
             .map_err(StorageError::from)?;
         let mut result = Vec::new();
         for row in rows {
@@ -613,17 +733,219 @@ impl SqliteStore {
              FROM hop GROUP BY triple ORDER BY MIN(depth), created_at DESC"
         );
 
-        let sql_params: Vec<rusqlite::types::Value> =
-            sql_params.iter().map(json_to_sql).collect();
+        let sql_params: Vec<rusqlite::types::Value> = sql_params.iter().map(json_to_sql).collect();
         let mut stmt = self.conn.prepare(&sql).map_err(StorageError::from)?;
         let rows = stmt
-            .query_map(rusqlite::params_from_iter(sql_params.clone()), row_to_statement)
+            .query_map(
+                rusqlite::params_from_iter(sql_params.clone()),
+                row_to_statement,
+            )
             .map_err(StorageError::from)?;
         let mut result = Vec::new();
         for row in rows {
             result.push(row.map_err(StorageError::from)?);
         }
         Ok(result)
+    }
+
+    pub fn embedding_version(&self, catalog: &str, key: &str) -> Result<Option<i64>> {
+        let (table, pk) = catalog_table(catalog)?;
+        Ok(self
+            .conn
+            .query_row(
+                &format!("SELECT content_version FROM {table} WHERE {pk}=?1"),
+                [key],
+                |r| r.get(0),
+            )
+            .optional()?)
+    }
+
+    pub fn install_embedding(
+        &self,
+        catalog: &str,
+        key: &str,
+        version: i64,
+        vector: &[f32],
+    ) -> Result<bool> {
+        let (table, pk) = catalog_table(catalog)?;
+        Ok(self.conn.execute(
+            &format!("UPDATE {table} SET embedding=?1 WHERE {pk}=?2 AND content_version=?3"),
+            params![vector_to_blob(vector), key, version],
+        )? == 1)
+    }
+
+    pub fn missing_embeddings(
+        &self,
+        catalog: &str,
+        after: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<(String, Content, i64)>> {
+        let (table, pk) = catalog_table(catalog)?;
+        let mut stmt = self.conn.prepare(&format!("SELECT {pk},content,content_version FROM {table} WHERE embedding IS NULL AND (?1 IS NULL OR {pk}>?1) ORDER BY {pk} LIMIT ?2"))?;
+        let rows = stmt.query_map(params![after, limit], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, i64>(2)?,
+            ))
+        })?;
+        rows.map(|r| {
+            let (key, c, v) = r?;
+            Ok((key, Content::from_json_str(&c)?, v))
+        })
+        .collect()
+    }
+
+    pub fn reset_embeddings(
+        &self,
+        metadata: &crate::storage::transfer::EmbeddingMetadata,
+    ) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        // Updating content to itself bumps versions, invalidating pre-reset jobs too.
+        tx.execute("UPDATE knowledge SET content=content,embedding=NULL", [])?;
+        tx.execute("UPDATE statement SET content=content,embedding=NULL", [])?;
+        tx.execute("INSERT INTO meta(k,v) VALUES('embedding_metadata',?1) ON CONFLICT(k) DO UPDATE SET v=excluded.v",[serde_json::to_string(metadata)?])?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn embedding_metadata(
+        &self,
+    ) -> Result<Option<crate::storage::transfer::EmbeddingMetadata>> {
+        let value: Option<String> = self
+            .conn
+            .query_row("SELECT v FROM meta WHERE k='embedding_metadata'", [], |r| {
+                r.get(0)
+            })
+            .optional()?;
+        value
+            .map(|s| serde_json::from_str(&s).map_err(Into::into))
+            .transpose()
+    }
+
+    pub fn configure_embedding(
+        &self,
+        metadata: &crate::storage::transfer::EmbeddingMetadata,
+    ) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        // Acquire the write lock before inspecting metadata to serialize first-open.
+        tx.execute("UPDATE meta SET v=v WHERE k='content_clock'", [])?;
+        if let Some(existing) = self.embedding_metadata()? {
+            if existing != *metadata {
+                return Err(HypatiaError::Config("embedding model or dimensions changed; import a --reembed snapshot into an empty shelf".into()));
+            }
+        } else if self.embedding_row_count("knowledge")? + self.embedding_row_count("statement")?
+            == 0
+        {
+            self.conn.execute(
+                "INSERT INTO meta(k,v) VALUES('embedding_metadata',?1)",
+                [serde_json::to_string(metadata)?],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn snapshot(&self) -> Result<crate::storage::transfer::Snapshot> {
+        use crate::storage::transfer::*;
+        let tx = self.conn.unchecked_transaction()?;
+        let embedding = self.embedding_metadata()?;
+        let knowledge = self.query_knowledge(
+            "SELECT name,content,created_at FROM knowledge ORDER BY name",
+            vec![],
+        )?;
+        let statements = self.query_statements("SELECT triple,head,relation,tail,content,created_at,tr_start,tr_end FROM statement ORDER BY triple", vec![])?;
+        let vector = |table: &str, pk: &str, key: &str| -> Result<Option<Vec<f32>>> {
+            if embedding.is_none() {
+                return Ok(None);
+            }
+            let blob: Option<Vec<u8>> = tx.query_row(
+                &format!("SELECT embedding FROM {table} WHERE {pk}=?1"),
+                [key],
+                |r| r.get(0),
+            )?;
+            Ok(blob.map(|b| blob_to_vector(&b)))
+        };
+        let knowledge = knowledge
+            .into_iter()
+            .map(|k| {
+                Ok(KnowledgeRecord {
+                    embedding: vector("knowledge", "name", &k.name)?,
+                    knowledge: k,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let statements = statements
+            .into_iter()
+            .map(|s| {
+                Ok(StatementRecord {
+                    embedding: vector("statement", "triple", &s.key.to_csv_key())?,
+                    statement: s,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        tx.commit()?;
+        Ok(Snapshot {
+            format_version: 1,
+            embedding,
+            knowledge,
+            statements,
+        })
+    }
+
+    pub fn import_snapshot(&self, snapshot: &crate::storage::transfer::Snapshot) -> Result<()> {
+        snapshot.validate()?;
+        let tx = self.conn.unchecked_transaction()?;
+        let count: i64 = tx.query_row(
+            "SELECT (SELECT COUNT(*) FROM knowledge)+(SELECT COUNT(*) FROM statement)",
+            [],
+            |r| r.get(0),
+        )?;
+        if count != 0 {
+            return Err(HypatiaError::Validation(
+                "import requires an empty target shelf".into(),
+            ));
+        }
+        if let Some(meta) = &snapshot.embedding {
+            if self.embedding_metadata()?.as_ref() != Some(meta) {
+                return Err(HypatiaError::Config(
+                    "snapshot embedding metadata differs from target; use --reembed".into(),
+                ));
+            }
+        }
+        for r in &snapshot.knowledge {
+            let k = &r.knowledge;
+            let json = k.content.to_json_string();
+            tx.execute(
+                "INSERT INTO knowledge(name,content,created_at,embedding) VALUES(?1,?2,?3,?4)",
+                params![
+                    k.name,
+                    json,
+                    format_timestamp(&k.created_at),
+                    r.embedding.as_ref().map(|v| vector_to_blob(v))
+                ],
+            )?;
+            let id =
+                self.docs_upsert_in(&tx, "knowledge", &k.name, &fts_doc_for(&k.content, &k.name))?;
+            replace_postings_in(&tx, id, &json)?;
+        }
+        for r in &snapshot.statements {
+            let s = &r.statement;
+            let triple = s.key.to_csv_key();
+            let json = s.content.to_json_string();
+            tx.execute("INSERT INTO statement(triple,head,relation,tail,content,created_at,tr_start,tr_end,embedding) VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9)", params![triple,s.key.head,s.key.relation,s.key.tail,json,format_timestamp(&s.created_at),s.tr_start.as_ref().map(format_timestamp),s.tr_end.as_ref().map(format_timestamp),r.embedding.as_ref().map(|v|vector_to_blob(v))])?;
+            let id =
+                self.docs_upsert_in(&tx, "statement", &triple, &fts_doc_for(&s.content, &triple))?;
+            replace_postings_in(&tx, id, &json)?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Online SQLite backup includes committed WAL contents in one consistent database.
+    pub fn backup_to(&self, path: &Path) -> Result<()> {
+        self.conn.backup("main", path, None)?;
+        Ok(())
     }
 
     // ── Embeddings (BLOB = source of truth) ──────────────────────────
@@ -691,9 +1013,7 @@ impl SqliteStore {
     }
 
     pub fn knowledge_without_embeddings(&self) -> Result<Vec<(String, String)>> {
-        self.entries_with_embeddings(
-            "SELECT name, content FROM knowledge WHERE embedding IS NULL",
-        )
+        self.entries_with_embeddings("SELECT name, content FROM knowledge WHERE embedding IS NULL")
     }
 
     pub fn statements_without_embeddings(&self) -> Result<Vec<(String, String)>> {
@@ -710,7 +1030,10 @@ impl SqliteStore {
             "statement" => "SELECT COUNT(*) FROM statement WHERE embedding IS NOT NULL",
             _ => "SELECT COUNT(*) FROM knowledge WHERE embedding IS NOT NULL",
         };
-        let n: i64 = self.conn.query_row(sql, [], |r| r.get(0)).map_err(StorageError::from)?;
+        let n: i64 = self
+            .conn
+            .query_row(sql, [], |r| r.get(0))
+            .map_err(StorageError::from)?;
         Ok(n as usize)
     }
 
@@ -765,7 +1088,9 @@ impl SqliteStore {
                      JOIN docs d ON d.catalog='statement' AND d.key = s.triple \
                      WHERE d.id IN ({placeholders})"
                 ),
-                ids.iter().map(|i| json_to_sql(&serde_json::Value::from(*i))).collect(),
+                ids.iter()
+                    .map(|i| json_to_sql(&serde_json::Value::from(*i)))
+                    .collect(),
             ),
             _ => (
                 format!(
@@ -773,7 +1098,9 @@ impl SqliteStore {
                      JOIN docs d ON d.catalog='knowledge' AND d.key = k.name \
                      WHERE d.id IN ({placeholders})"
                 ),
-                ids.iter().map(|i| json_to_sql(&serde_json::Value::from(*i))).collect(),
+                ids.iter()
+                    .map(|i| json_to_sql(&serde_json::Value::from(*i)))
+                    .collect(),
             ),
         };
         let mut stmt = self.conn.prepare(&sql).map_err(StorageError::from)?;
@@ -859,7 +1186,11 @@ impl SqliteStore {
              LEFT JOIN statement s ON d.catalog = 'statement' AND s.triple = d.key \
              WHERE docs_fts MATCH ?1 {} \
              ORDER BY rank LIMIT ?2 OFFSET ?3",
-            if catalog_filter.is_some() { "AND d.catalog = ?4" } else { "" }
+            if catalog_filter.is_some() {
+                "AND d.catalog = ?4"
+            } else {
+                ""
+            }
         );
         let mut stmt = self.conn.prepare(&sql).map_err(StorageError::from)?;
         let map_row = |row: &rusqlite::Row| -> rusqlite::Result<FtsResult> {
@@ -872,9 +1203,12 @@ impl SqliteStore {
             })
         };
         let rows: Vec<rusqlite::Result<FtsResult>> = if let Some(cat) = catalog_filter {
-            stmt.query_map(rusqlite::params![query, opts.limit, opts.offset, cat], map_row)
-                .map_err(StorageError::from)?
-                .collect()
+            stmt.query_map(
+                rusqlite::params![query, opts.limit, opts.offset, cat],
+                map_row,
+            )
+            .map_err(StorageError::from)?
+            .collect()
         } else {
             stmt.query_map(rusqlite::params![query, opts.limit, opts.offset], map_row)
                 .map_err(StorageError::from)?
@@ -907,9 +1241,33 @@ pub fn sanitize_fts_query(query: &str) -> String {
         .map(|c| {
             matches!(
                 c,
-                ':' | '"' | '\'' | '*' | '^' | '+' | '-' | '(' | ')' | '.' | '?'
-                | '!' | ',' | '/' | '`' | '{' | '}' | '[' | ']' | '~' | '@'
-                | '#' | '%' | ';' | '&' | '|' | '<' | '>'
+                ':' | '"'
+                    | '\''
+                    | '*'
+                    | '^'
+                    | '+'
+                    | '-'
+                    | '('
+                    | ')'
+                    | '.'
+                    | '?'
+                    | '!'
+                    | ','
+                    | '/'
+                    | '`'
+                    | '{'
+                    | '}'
+                    | '['
+                    | ']'
+                    | '~'
+                    | '@'
+                    | '#'
+                    | '%'
+                    | ';'
+                    | '&'
+                    | '|'
+                    | '<'
+                    | '>'
             )
             .then_some(' ')
             .unwrap_or(c)
@@ -1070,7 +1428,10 @@ mod tests {
         {
             let store = SqliteStore::open(&db_path).unwrap();
             store
-                .insert_knowledge("rust", &Content::new("Rust is a systems programming language"))
+                .insert_knowledge(
+                    "rust",
+                    &Content::new("Rust is a systems programming language"),
+                )
                 .unwrap();
         }
         {
@@ -1111,7 +1472,9 @@ mod tests {
         store
             .insert_knowledge("auth", &Content::new("user authenticating via OAuth2"))
             .unwrap();
-        let results = store.search("authentication", &SearchOpts::default()).unwrap();
+        let results = store
+            .search("authentication", &SearchOpts::default())
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].key, "auth");
     }
@@ -1141,7 +1504,11 @@ mod tests {
         let rows = store
             .query_knowledge(
                 "SELECT name, content, created_at FROM knowledge WHERE name = ? LIMIT ? OFFSET ?",
-                vec![serde_json::json!("k1"), serde_json::json!(100), serde_json::json!(0)],
+                vec![
+                    serde_json::json!("k1"),
+                    serde_json::json!(100),
+                    serde_json::json!(0),
+                ],
             )
             .unwrap();
         assert_eq!(rows.len(), 1);
@@ -1161,7 +1528,9 @@ mod tests {
         let vector_a = vec![1.0f32; 64];
         let vector_b = vec![0.0f32; 64];
         store.upsert_knowledge_embedding("rust", &vector_a).unwrap();
-        store.upsert_knowledge_embedding("python", &vector_b).unwrap();
+        store
+            .upsert_knowledge_embedding("python", &vector_b)
+            .unwrap();
 
         let results = store.vector_search_knowledge(&vector_a, 10).unwrap();
         assert_eq!(results.len(), 2);
@@ -1171,11 +1540,17 @@ mod tests {
     #[test]
     fn vector_search_excludes_null_embeddings() {
         let (_dir, store) = setup();
-        store.insert_knowledge("with_vec", &Content::new("data")).unwrap();
-        store.insert_knowledge("no_vec", &Content::new("data")).unwrap();
+        store
+            .insert_knowledge("with_vec", &Content::new("data"))
+            .unwrap();
+        store
+            .insert_knowledge("no_vec", &Content::new("data"))
+            .unwrap();
 
         let vector = vec![0.5f32; 32];
-        store.upsert_knowledge_embedding("with_vec", &vector).unwrap();
+        store
+            .upsert_knowledge_embedding("with_vec", &vector)
+            .unwrap();
 
         let results = store.vector_search_knowledge(&vector, 10).unwrap();
         assert_eq!(results.len(), 1);
@@ -1185,11 +1560,17 @@ mod tests {
     #[test]
     fn without_embeddings_lists_only_missing() {
         let (_dir, store) = setup();
-        store.insert_knowledge("has_vec", &Content::new("data")).unwrap();
-        store.insert_knowledge("no_vec", &Content::new("data")).unwrap();
+        store
+            .insert_knowledge("has_vec", &Content::new("data"))
+            .unwrap();
+        store
+            .insert_knowledge("no_vec", &Content::new("data"))
+            .unwrap();
 
         let vector = vec![0.5f32; 32];
-        store.upsert_knowledge_embedding("has_vec", &vector).unwrap();
+        store
+            .upsert_knowledge_embedding("has_vec", &vector)
+            .unwrap();
 
         let missing = store.knowledge_without_embeddings().unwrap();
         assert_eq!(missing.len(), 1);
@@ -1212,10 +1593,20 @@ mod tests {
     fn khop_1hop_specific_relation() {
         let (_dir, store) = setup();
         store
-            .insert_statement(&StatementKey::new("Alice", "knows", "Bob"), &Content::new("a->b"), None, None)
+            .insert_statement(
+                &StatementKey::new("Alice", "knows", "Bob"),
+                &Content::new("a->b"),
+                None,
+                None,
+            )
             .unwrap();
         store
-            .insert_statement(&StatementKey::new("Bob", "knows", "Carol"), &Content::new("b->c"), None, None)
+            .insert_statement(
+                &StatementKey::new("Bob", "knows", "Carol"),
+                &Content::new("b->c"),
+                None,
+                None,
+            )
             .unwrap();
 
         let results = store.query_khop("Alice", Some("knows"), 1).unwrap();
@@ -1227,13 +1618,28 @@ mod tests {
     fn khop_2hop_specific_relation() {
         let (_dir, store) = setup();
         store
-            .insert_statement(&StatementKey::new("Alice", "knows", "Bob"), &Content::new("a->b"), None, None)
+            .insert_statement(
+                &StatementKey::new("Alice", "knows", "Bob"),
+                &Content::new("a->b"),
+                None,
+                None,
+            )
             .unwrap();
         store
-            .insert_statement(&StatementKey::new("Bob", "knows", "Carol"), &Content::new("b->c"), None, None)
+            .insert_statement(
+                &StatementKey::new("Bob", "knows", "Carol"),
+                &Content::new("b->c"),
+                None,
+                None,
+            )
             .unwrap();
         store
-            .insert_statement(&StatementKey::new("Bob", "works_with", "Dave"), &Content::new("b->d"), None, None)
+            .insert_statement(
+                &StatementKey::new("Bob", "works_with", "Dave"),
+                &Content::new("b->d"),
+                None,
+                None,
+            )
             .unwrap();
 
         let results = store.query_khop("Alice", Some("knows"), 2).unwrap();
@@ -1247,13 +1653,28 @@ mod tests {
     fn khop_wildcard_relation() {
         let (_dir, store) = setup();
         store
-            .insert_statement(&StatementKey::new("Alice", "knows", "Bob"), &Content::new("a->b"), None, None)
+            .insert_statement(
+                &StatementKey::new("Alice", "knows", "Bob"),
+                &Content::new("a->b"),
+                None,
+                None,
+            )
             .unwrap();
         store
-            .insert_statement(&StatementKey::new("Bob", "knows", "Carol"), &Content::new("b->c"), None, None)
+            .insert_statement(
+                &StatementKey::new("Bob", "knows", "Carol"),
+                &Content::new("b->c"),
+                None,
+                None,
+            )
             .unwrap();
         store
-            .insert_statement(&StatementKey::new("Bob", "works_with", "Dave"), &Content::new("b->d"), None, None)
+            .insert_statement(
+                &StatementKey::new("Bob", "works_with", "Dave"),
+                &Content::new("b->d"),
+                None,
+                None,
+            )
             .unwrap();
 
         let results = store.query_khop("Alice", None, 2).unwrap();
@@ -1268,10 +1689,20 @@ mod tests {
     fn khop_cycle() {
         let (_dir, store) = setup();
         store
-            .insert_statement(&StatementKey::new("A", "knows", "B"), &Content::new("a->b"), None, None)
+            .insert_statement(
+                &StatementKey::new("A", "knows", "B"),
+                &Content::new("a->b"),
+                None,
+                None,
+            )
             .unwrap();
         store
-            .insert_statement(&StatementKey::new("B", "knows", "A"), &Content::new("b->a"), None, None)
+            .insert_statement(
+                &StatementKey::new("B", "knows", "A"),
+                &Content::new("b->a"),
+                None,
+                None,
+            )
             .unwrap();
 
         let results = store.query_khop("A", Some("knows"), 5).unwrap();
@@ -1300,8 +1731,8 @@ mod tests {
             .unwrap();
 
         use crate::engine::ast::AstNode;
+        use crate::engine::operators::{OpContext, evaluate_operator};
         use crate::model::QueryTarget;
-        use crate::engine::operators::{evaluate_operator, OpContext};
         let ctx = OpContext::for_target(QueryTarget::Knowledge);
         let mut map = serde_json::Map::new();
         map.insert("tags".to_string(), serde_json::json!(["refactor"]));
@@ -1319,9 +1750,7 @@ mod tests {
             }
             other => panic!("expected SqlCondition, got {other:?}"),
         };
-        let sql = format!(
-            "SELECT name, content, created_at FROM knowledge WHERE {fragment}"
-        );
+        let sql = format!("SELECT name, content, created_at FROM knowledge WHERE {fragment}");
         let rows = store.query_knowledge(&sql, params).unwrap();
         let names: Vec<String> = rows.into_iter().map(|k| k.name).collect();
         assert_eq!(names, vec!["plan".to_string()], "fragment: {fragment}");
@@ -1332,10 +1761,12 @@ mod tests {
         assert_eq!(rows.len(), 1, "recall failed");
 
         // Split: recheck only
-        let recheck_only =
-            "SELECT name, content, created_at FROM knowledge WHERE name = 'plan' AND json_contains(content, ?)";
+        let recheck_only = "SELECT name, content, created_at FROM knowledge WHERE name = 'plan' AND json_contains(content, ?)";
         let rows = store
-            .query_knowledge(recheck_only, vec![serde_json::json!({"tags": ["refactor"]})])
+            .query_knowledge(
+                recheck_only,
+                vec![serde_json::json!({"tags": ["refactor"]})],
+            )
             .unwrap();
         let recheck_names: Vec<String> = rows.into_iter().map(|k| k.name).collect();
         assert_eq!(recheck_names, vec!["plan".to_string()], "recheck failed");

--- a/src/storage/transfer.rs
+++ b/src/storage/transfer.rs
@@ -1,0 +1,230 @@
+//! Versioned backend-neutral snapshots. Credentials and local model paths are excluded.
+use crate::error::{HypatiaError, Result};
+use crate::model::{Knowledge, Statement};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EmbeddingMetadata {
+    pub model: String,
+    pub dimensions: usize,
+    pub metric: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct KnowledgeRecord {
+    pub knowledge: Knowledge,
+    pub embedding: Option<Vec<f32>>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatementRecord {
+    pub statement: Statement,
+    pub embedding: Option<Vec<f32>>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Snapshot {
+    pub format_version: u32,
+    pub embedding: Option<EmbeddingMetadata>,
+    pub knowledge: Vec<KnowledgeRecord>,
+    pub statements: Vec<StatementRecord>,
+}
+impl Snapshot {
+    pub fn validate(&self) -> Result<()> {
+        if self.format_version != 1 {
+            return Err(HypatiaError::Validation(
+                "unsupported logical snapshot version".into(),
+            ));
+        }
+        let mut keys = std::collections::HashSet::new();
+        for r in &self.knowledge {
+            if !keys.insert(r.knowledge.name.clone()) {
+                return Err(HypatiaError::Validation(
+                    "snapshot contains duplicate knowledge keys".into(),
+                ));
+            }
+            self.validate_vector(r.embedding.as_deref())?;
+        }
+        keys.clear();
+        for r in &self.statements {
+            if !keys.insert(r.statement.key.to_csv_key()) {
+                return Err(HypatiaError::Validation(
+                    "snapshot contains duplicate statement keys".into(),
+                ));
+            }
+            self.validate_vector(r.embedding.as_deref())?;
+        }
+        Ok(())
+    }
+    fn validate_vector(&self, vector: Option<&[f32]>) -> Result<()> {
+        if let Some(v) = vector {
+            let meta = self.embedding.as_ref().ok_or_else(|| {
+                HypatiaError::Validation(
+                    "vectors require trusted model metadata; use --reembed".into(),
+                )
+            })?;
+            validate_vector(v, meta.dimensions)?;
+            if meta.metric != "cosine" || meta.model.is_empty() {
+                return Err(HypatiaError::Validation(
+                    "invalid embedding metadata".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+    pub fn without_embeddings(mut self) -> Self {
+        self.embedding = None;
+        for r in &mut self.knowledge {
+            r.embedding = None;
+        }
+        for r in &mut self.statements {
+            r.embedding = None;
+        }
+        self
+    }
+}
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    pub format_version: u32,
+    pub knowledge_count: usize,
+    pub statement_count: usize,
+    pub files: std::collections::BTreeMap<String, String>,
+}
+fn checksum(path: &std::path::Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut hash = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hash.update(&buf[..n]);
+    }
+    Ok(hash.finalize().iter().map(|b| format!("{b:02x}")).collect())
+}
+fn archive_files(
+    base: &std::path::Path,
+    dir: &std::path::Path,
+    files: &mut std::collections::BTreeMap<String, String>,
+) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let kind = entry.file_type()?;
+        let path = entry.path();
+        if kind.is_symlink() {
+            return Err(HypatiaError::Validation(
+                "archive exports cannot contain symlinks".into(),
+            ));
+        }
+        if kind.is_dir() {
+            archive_files(base, &path, files)?;
+        } else if kind.is_file() {
+            let relative = path
+                .strip_prefix(base)
+                .map_err(|_| HypatiaError::Validation("archive path outside package".into()))?;
+            let key = relative
+                .to_str()
+                .ok_or_else(|| HypatiaError::Validation("archive filenames must be UTF-8".into()))?
+                .replace('\\', "/");
+            files.insert(key, checksum(&path)?);
+        } else {
+            return Err(HypatiaError::Validation(
+                "archives must contain regular files only".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+pub fn write_manifest(root: &std::path::Path, snapshot: &Snapshot) -> Result<()> {
+    let mut files = std::collections::BTreeMap::new();
+    files.insert(
+        "snapshot.json".into(),
+        checksum(&root.join("snapshot.json"))?,
+    );
+    archive_files(root, &root.join("archives"), &mut files)?;
+    let manifest = Manifest {
+        format_version: 1,
+        knowledge_count: snapshot.knowledge.len(),
+        statement_count: snapshot.statements.len(),
+        files,
+    };
+    serde_json::to_writer_pretty(
+        std::fs::File::create(root.join("manifest.json"))?,
+        &manifest,
+    )?;
+    Ok(())
+}
+pub fn verify_manifest(root: &std::path::Path, snapshot: &Snapshot) -> Result<()> {
+    let manifest: Manifest =
+        serde_json::from_reader(std::fs::File::open(root.join("manifest.json"))?)?;
+    if manifest.format_version != 1
+        || manifest.knowledge_count != snapshot.knowledge.len()
+        || manifest.statement_count != snapshot.statements.len()
+        || !manifest.files.contains_key("snapshot.json")
+    {
+        return Err(HypatiaError::Validation(
+            "logical export manifest version or row counts differ".into(),
+        ));
+    }
+    let mut actual = std::collections::BTreeMap::new();
+    actual.insert(
+        "snapshot.json".into(),
+        checksum(&root.join("snapshot.json"))?,
+    );
+    archive_files(root, &root.join("archives"), &mut actual)?;
+    if actual != manifest.files {
+        return Err(HypatiaError::Validation(
+            "export checksum verification failed; preserve the original package".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_archives(snapshot: &Snapshot, root: &std::path::Path) -> Result<()> {
+    for content in snapshot
+        .knowledge
+        .iter()
+        .map(|r| &r.knowledge.content)
+        .chain(snapshot.statements.iter().map(|r| &r.statement.content))
+    {
+        for reference in content.figures.iter().flatten() {
+            if let Some(relative) = reference.strip_prefix("archive://") {
+                let path = std::path::Path::new(relative);
+                if relative.is_empty()
+                    || path
+                        .components()
+                        .any(|c| !matches!(c, std::path::Component::Normal(_)))
+                {
+                    return Err(HypatiaError::Validation(format!(
+                        "invalid archive reference: {reference}"
+                    )));
+                }
+                let canonical = root.canonicalize()?;
+                let file = root.join(path).canonicalize()?;
+                if !file.starts_with(&canonical) || !file.is_file() {
+                    return Err(HypatiaError::Validation(format!(
+                        "missing or unsafe archive reference: {reference}"
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_vector(vector: &[f32], dims: usize) -> Result<()> {
+    if vector.len() != dims
+        || vector.is_empty()
+        || vector.iter().any(|v| !v.is_finite())
+        || vector.iter().all(|v| *v == 0.0)
+    {
+        return Err(HypatiaError::Validation(format!(
+            "embedding must contain {dims} finite values and have nonzero norm"
+        )));
+    }
+    Ok(())
+}

--- a/src/storage/vector_index.rs
+++ b/src/storage/vector_index.rs
@@ -10,7 +10,7 @@
 
 use std::path::Path;
 
-use usearch::{new_index, Index, IndexOptions, MetricKind, ScalarKind};
+use usearch::{Index, IndexOptions, MetricKind, ScalarKind, new_index};
 
 use crate::error::{Result, StorageError};
 pub struct VectorFileIndex {
@@ -22,12 +22,9 @@ pub struct VectorFileIndex {
 
 impl VectorFileIndex {
     /// Build a fresh in-memory index and insert every item.
-    pub fn build(
-        path: &Path,
-        dimensions: usize,
-        items: &[(i64, Vec<f32>)],
-    ) -> Result<Self> {
-        let index = new_index(&options(dimensions)).map_err(|e| StorageError::Vector(e.to_string()))?;
+    pub fn build(path: &Path, dimensions: usize, items: &[(i64, Vec<f32>)]) -> Result<Self> {
+        let index =
+            new_index(&options(dimensions)).map_err(|e| StorageError::Vector(e.to_string()))?;
         index
             .reserve(items.len().max(64))
             .map_err(|e| StorageError::Vector(e.to_string()))?;
@@ -50,8 +47,11 @@ impl VectorFileIndex {
     /// Load an existing index file. Errors if absent/corrupt — caller falls
     /// back to `build`.
     pub fn load(path: &Path, dimensions: usize) -> Result<Self> {
-        let index = new_index(&options(dimensions)).map_err(|e| StorageError::Vector(e.to_string()))?;
-        index.load(path.to_str().unwrap_or("")).map_err(|e| StorageError::Vector(e.to_string()))?;
+        let index =
+            new_index(&options(dimensions)).map_err(|e| StorageError::Vector(e.to_string()))?;
+        index
+            .load(path.to_str().unwrap_or(""))
+            .map_err(|e| StorageError::Vector(e.to_string()))?;
         Ok(Self {
             index,
             dimensions,
@@ -106,7 +106,10 @@ impl VectorFileIndex {
             return Ok(Vec::new());
         }
         let k = k.min(self.index.size());
-        let results = self.index.search(query, k).map_err(|e| StorageError::Vector(e.to_string()))?;
+        let results = self
+            .index
+            .search(query, k)
+            .map_err(|e| StorageError::Vector(e.to_string()))?;
         Ok(results
             .keys
             .iter()
@@ -115,14 +118,24 @@ impl VectorFileIndex {
             .collect())
     }
 
-    /// Atomic snapshot: save to `<path>.tmp` then rename into place.
+    /// Atomic snapshot with a uniquely reserved temporary file per writer.
     pub fn save(&mut self) -> Result<()> {
         if !self.dirty {
             return Ok(());
         }
-        let tmp = suffix_path(&self.path, ".tmp");
-        self.index.save(tmp.to_str().unwrap_or("")).map_err(|e| StorageError::Vector(e.to_string()))?;
-        std::fs::rename(&tmp, &self.path)?;
+        let (tmp, file) = reserve_temporary(&self.path)?;
+        drop(file);
+        let result = (|| -> Result<()> {
+            self.index
+                .save(tmp.to_str().unwrap_or(""))
+                .map_err(|e| StorageError::Vector(e.to_string()))?;
+            std::fs::rename(&tmp, &self.path)?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&tmp);
+        }
+        result?;
         self.dirty = false;
         Ok(())
     }
@@ -130,6 +143,44 @@ impl VectorFileIndex {
     pub fn is_dirty(&self) -> bool {
         self.dirty
     }
+}
+
+/// Reserve a distinct sibling temporary file even for simultaneous writers.
+fn reserve_temporary(path: &Path) -> Result<(std::path::PathBuf, std::fs::File)> {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    loop {
+        let seq = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let tmp = suffix_path(path, &format!(".{}.{}.{seq}.tmp", std::process::id(), time));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)
+        {
+            Ok(file) => return Ok((tmp, file)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    let (tmp, mut file) = reserve_temporary(path)?;
+    let result = (|| -> Result<()> {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
 }
 
 fn options(dimensions: usize) -> IndexOptions {
@@ -155,14 +206,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn concurrent_atomic_saves_do_not_share_temporary_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared.usearch");
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(4));
+        let handles: Vec<_> = (0..4)
+            .map(|i| {
+                let path = path.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    let mut index = VectorFileIndex::build(&path, 2, &[(i, vec![1., 0.])]).unwrap();
+                    barrier.wait();
+                    index.save().unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(VectorFileIndex::load(&path, 2).unwrap().size(), 1);
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
     fn build_search_save_load_roundtrip() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("knowledge.usearch");
 
-        let items = vec![
-            (1i64, vec![1.0f32, 0.0, 0.0]),
-            (2i64, vec![0.0, 1.0, 0.0]),
-        ];
+        let items = vec![(1i64, vec![1.0f32, 0.0, 0.0]), (2i64, vec![0.0, 1.0, 0.0])];
         let mut index = VectorFileIndex::build(&path, 3, &items).unwrap();
         assert_eq!(index.size(), 2);
 

--- a/tests/backend_contract.rs
+++ b/tests/backend_contract.rs
@@ -1,0 +1,452 @@
+//! Shared domain contracts, including a real optional PostgreSQL target.
+use hypatia::{
+    engine::Evaluator,
+    model::{Content, QueryTarget, SearchOpts, StatementKey},
+    storage::{OpenShelf, ShelfManager, Storage},
+};
+use serde_json::json;
+use tempfile::TempDir;
+
+fn local(dir: &TempDir) -> OpenShelf {
+    std::fs::write(
+        dir.path().join("shelf.toml"),
+        "[embedding]\nmodel='hypatia-contract-test'\ndimensions=3\n",
+    )
+    .unwrap();
+    OpenShelf::open(dir.path(), Some("contract")).unwrap()
+}
+fn contract(shelf: &mut OpenShelf) {
+    let initial = Content::new(r#"{"n":12,"mixed":[1,"rust",null],"nested":{"x":true}}"#)
+        .with_tags(vec!["rust".into()]);
+    let version = shelf.backend.insert_knowledge("first", &initial).unwrap();
+    assert!(shelf.backend.insert_knowledge("first", &initial).is_err());
+    assert!(
+        shelf
+            .backend
+            .install_embedding("knowledge", "first", version, &[1., 0., 0.])
+            .unwrap()
+    );
+    let hits = shelf
+        .backend
+        .vector_search(QueryTarget::Knowledge, &[1., 0., 0.], 10)
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].2.abs() < 1e-5);
+    for v in [
+        vec![0., 0., 0.],
+        vec![1., 2.],
+        vec![f32::NAN, 1., 0.],
+        vec![f32::INFINITY, 0., 1.],
+    ] {
+        assert!(
+            shelf
+                .backend
+                .install_embedding("knowledge", "first", version, &v)
+                .is_err()
+        );
+    }
+    for expression in [
+        json!(["$knowledge", ["$has", "tags", "rust"]]),
+        json!(["$knowledge", ["$eq", "$name", "first"]]),
+        json!(["$knowledge", ["$has", "data.mixed", 1]]),
+    ] {
+        assert_eq!(
+            Evaluator::execute(&expression, shelf).unwrap().rows.len(),
+            1,
+            "{expression}"
+        );
+    }
+    let next = shelf
+        .backend
+        .update_knowledge("first", &Content::new("更新正文 storage"))
+        .unwrap();
+    assert_ne!(version, next);
+    assert!(
+        !shelf
+            .backend
+            .install_embedding("knowledge", "first", version, &[1., 0., 0.])
+            .unwrap()
+    );
+    assert!(
+        shelf
+            .backend
+            .vector_search(QueryTarget::Knowledge, &[1., 0., 0.], 10)
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        shelf
+            .backend
+            .missing_embeddings("knowledge", None, 1)
+            .unwrap()[0]
+            .2,
+        next
+    );
+    assert!(
+        shelf
+            .backend
+            .install_embedding("knowledge", "first", next, &[0., 1., 0.])
+            .unwrap()
+    );
+    shelf.backend.rebuild_indexes().unwrap();
+    assert_eq!(
+        shelf
+            .execute_search("storage", &SearchOpts::default())
+            .unwrap()
+            .rows
+            .len(),
+        1
+    );
+    assert_eq!(
+        shelf
+            .execute_search("正文", &SearchOpts::default())
+            .unwrap()
+            .rows
+            .len(),
+        1
+    );
+    let a = StatementKey::new("first", "links", "second");
+    let b = StatementKey::new("second", "links", "first");
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+        .unwrap()
+        .and_hms_opt(1, 2, 3)
+        .unwrap();
+    shelf
+        .backend
+        .insert_statement(&a, &Content::new("edge"), Some(date), None)
+        .unwrap();
+    shelf
+        .backend
+        .insert_statement(&b, &Content::new("cycle"), None, None)
+        .unwrap();
+    assert_eq!(
+        shelf.backend.get_statement(&a).unwrap().unwrap().tr_start,
+        Some(date)
+    );
+    assert_eq!(
+        shelf
+            .backend
+            .query_khop("first", Some("links"), 3)
+            .unwrap()
+            .len(),
+        2
+    );
+    shelf.backend.delete_knowledge("first").unwrap();
+    assert!(shelf.backend.delete_knowledge("first").is_err());
+    let recreated = shelf.backend.insert_knowledge("first", &initial).unwrap();
+    assert_ne!(recreated, next);
+    assert!(
+        !shelf
+            .backend
+            .install_embedding("knowledge", "first", next, &[0., 1., 0.])
+            .unwrap()
+    );
+    assert!(
+        shelf
+            .backend
+            .vector_search(QueryTarget::Knowledge, &[1., 0., 0.], 10)
+            .unwrap()
+            .is_empty()
+    );
+}
+#[test]
+fn sqlite_shared_contract() {
+    let dir = TempDir::new().unwrap();
+    contract(&mut local(&dir));
+}
+#[test]
+fn invalid_config_never_creates_local_storage() {
+    for config in [
+        "[storage]\nbackend='pgvector'\n",
+        "[storage]\nbacked='pgvector'\n",
+        "not toml",
+    ] {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("shelf.toml"), config).unwrap();
+        assert!(OpenShelf::open(dir.path(), None).is_err());
+        assert!(!dir.path().join("hypatia.sqlite").exists());
+        assert!(!dir.path().join("vectors").exists());
+    }
+}
+#[test]
+fn stale_sqlite_writer_cannot_reinstall_after_delete_or_update() {
+    let dir = TempDir::new().unwrap();
+    let mut one = local(&dir);
+    let two = OpenShelf::open(dir.path(), None).unwrap();
+    let version = one
+        .backend
+        .insert_knowledge("key", &Content::new("old"))
+        .unwrap();
+    one.backend
+        .install_embedding("knowledge", "key", version, &[1., 0., 0.])
+        .unwrap();
+    one.backend.rebuild_indexes().unwrap();
+    two.backend
+        .update_knowledge("key", &Content::new("new"))
+        .unwrap();
+    assert!(
+        !one.backend
+            .install_embedding("knowledge", "key", version, &[1., 0., 0.])
+            .unwrap()
+    );
+    assert!(
+        one.backend
+            .vector_search(QueryTarget::Knowledge, &[1., 0., 0.], 1)
+            .unwrap()
+            .is_empty()
+    );
+}
+#[test]
+fn logical_export_import_preserves_content_time_vectors_and_archives() {
+    let home = TempDir::new().unwrap();
+    let source = TempDir::new().unwrap();
+    let target = TempDir::new().unwrap();
+    let export = TempDir::new().unwrap();
+    for dir in [&source, &target] {
+        std::fs::write(
+            dir.path().join("shelf.toml"),
+            "[embedding]\nmodel='hypatia-contract-test'\ndimensions=3\n",
+        )
+        .unwrap();
+    }
+    let mut mgr = ShelfManager::with_home(home.path().into()).unwrap();
+    mgr.connect(source.path(), Some("source")).unwrap();
+    mgr.connect(target.path(), Some("target")).unwrap();
+    let src = mgr.get_mut("source").unwrap();
+    std::fs::write(src.config.archives_path.join("figure.txt"), "attachment").unwrap();
+    let version = src
+        .backend
+        .insert_knowledge(
+            "key",
+            &Content::new("body").with_figures(vec!["archive://figure.txt".into()]),
+        )
+        .unwrap();
+    src.backend
+        .install_embedding("knowledge", "key", version, &[1., 0., 0.])
+        .unwrap();
+    let expected = src.backend.snapshot().unwrap();
+    mgr.export("source", export.path()).unwrap();
+    assert!(export.path().join("hypatia.sqlite").exists());
+    mgr.import("target", export.path(), false).unwrap();
+    assert_eq!(
+        mgr.get("target").unwrap().backend.snapshot().unwrap(),
+        expected
+    );
+    assert_eq!(
+        std::fs::read(target.path().join("archives/figure.txt")).unwrap(),
+        b"attachment"
+    );
+    assert!(mgr.import("target", export.path(), false).is_err());
+}
+#[cfg(not(feature = "postgres-backend"))]
+#[test]
+fn missing_feature_is_explicit() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("shelf.toml"),"[storage]\nbackend='pgvector'\n[storage.postgres]\nurl_env='HYPATIA_TEST_POSTGRES_URL'\nschema='feature_test'\n[embedding]\nmodel='hypatia-contract-test'\n").unwrap();
+    let err = OpenShelf::open(dir.path(), None).err().unwrap().to_string();
+    assert!(err.contains("--features postgres-backend"));
+    assert!(!dir.path().join("hypatia.sqlite").exists());
+}
+
+#[cfg(feature = "postgres-backend")]
+#[test]
+#[ignore = "requires disposable pgvector database"]
+fn sqlite_pg_sqlite_migration_includes_new_pg_writes() {
+    std::env::var("HYPATIA_TEST_POSTGRES_URL").expect("HYPATIA_TEST_POSTGRES_URL required");
+    let root = TempDir::new().unwrap();
+    let source = root.path().join("source");
+    let pgdir = root.path().join("pg");
+    let returned = root.path().join("returned");
+    for dir in [&source, &pgdir, &returned] {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+    let model = "[embedding]\nmodel='hypatia-contract-test'\ndimensions=3\n";
+    std::fs::write(source.join("shelf.toml"), model).unwrap();
+    std::fs::write(returned.join("shelf.toml"), model).unwrap();
+    let schema = format!(
+        "roundtrip_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    std::fs::write(pgdir.join("shelf.toml"),format!("[storage]\nbackend='pgvector'\n[storage.postgres]\nurl_env='HYPATIA_TEST_POSTGRES_URL'\nschema='{schema}'\n{model}")).unwrap();
+    let mut mgr = ShelfManager::with_home(root.path().join("home")).unwrap();
+    mgr.connect(&source, Some("source")).unwrap();
+    mgr.connect(&pgdir, Some("pg")).unwrap();
+    mgr.connect(&returned, Some("returned")).unwrap();
+    let src = mgr.get_mut("source").unwrap();
+    std::fs::write(
+        src.config.archives_path.join("figure.txt"),
+        b"local attachment",
+    )
+    .unwrap();
+    let v = src
+        .backend
+        .insert_knowledge(
+            "original",
+            &Content::new("original text").with_figures(vec!["archive://figure.txt".into()]),
+        )
+        .unwrap();
+    src.backend
+        .install_embedding("knowledge", "original", v, &[1., 0., 0.])
+        .unwrap();
+    let key = StatementKey::new("original", "linked", "later");
+    src.backend
+        .insert_statement(&key, &Content::new("relation"), None, None)
+        .unwrap();
+    let first = root.path().join("to-pg");
+    mgr.export("source", &first).unwrap();
+    mgr.import("pg", &first, false).unwrap();
+    let pg = mgr.get_mut("pg").unwrap();
+    let v = pg
+        .backend
+        .insert_knowledge("added-in-pg", &Content::new("after switch"))
+        .unwrap();
+    pg.backend
+        .install_embedding("knowledge", "added-in-pg", v, &[0., 1., 0.])
+        .unwrap();
+    let second = root.path().join("to-sqlite");
+    mgr.export("pg", &second).unwrap();
+    assert!(!second.join("hypatia.sqlite").exists());
+    assert!(!second.join("shelf.toml").exists());
+    mgr.import("returned", &second, false).unwrap();
+    assert!(
+        mgr.get("returned")
+            .unwrap()
+            .backend
+            .get_knowledge("added-in-pg")
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        mgr.get("source")
+            .unwrap()
+            .backend
+            .get_knowledge("added-in-pg")
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        mgr.get("returned")
+            .unwrap()
+            .backend
+            .embedding_row_count("knowledge")
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        std::fs::read(returned.join("archives/figure.txt")).unwrap(),
+        b"local attachment"
+    );
+    // Tampering is rejected before target data is written.
+    std::fs::write(second.join("archives/figure.txt"), b"tampered").unwrap();
+    let fresh = root.path().join("fresh");
+    std::fs::create_dir_all(&fresh).unwrap();
+    std::fs::write(fresh.join("shelf.toml"), model).unwrap();
+    mgr.connect(&fresh, Some("fresh")).unwrap();
+    assert!(
+        mgr.import("fresh", &second, false)
+            .unwrap_err()
+            .to_string()
+            .contains("checksum")
+    );
+    assert!(
+        mgr.get("fresh")
+            .unwrap()
+            .backend
+            .snapshot()
+            .unwrap()
+            .knowledge
+            .is_empty()
+    );
+    drop(mgr);
+    let mut admin = postgres::Client::connect(
+        &std::env::var("HYPATIA_TEST_POSTGRES_URL").unwrap(),
+        postgres::NoTls,
+    )
+    .unwrap();
+    admin
+        .batch_execute(&format!("DROP SCHEMA \"{schema}\" CASCADE"))
+        .unwrap();
+}
+
+#[cfg(feature = "postgres-backend")]
+#[test]
+#[ignore = "requires HYPATIA_TEST_POSTGRES_URL pointing at disposable pgvector database"]
+fn postgres_shared_contract_and_mixed_shelf_isolation() {
+    std::env::var("HYPATIA_TEST_POSTGRES_URL").expect("HYPATIA_TEST_POSTGRES_URL required");
+    let home = TempDir::new().unwrap();
+    let one = TempDir::new().unwrap();
+    let two = TempDir::new().unwrap();
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let schemas = [
+        format!("contract_{suffix}_a"),
+        format!("contract_{suffix}_b"),
+    ];
+    let direct_url = std::env::var("HYPATIA_TEST_POSTGRES_URL").unwrap();
+    for (dir, schema) in [(&one, &schemas[0]), (&two, &schemas[1])] {
+        let connection = if dir.path() == one.path() {
+            "url_env='HYPATIA_TEST_POSTGRES_URL'\n".to_string()
+        } else {
+            toml::to_string(&std::collections::BTreeMap::from([("url", &direct_url)])).unwrap()
+        };
+        std::fs::write(dir.path().join("shelf.toml"),format!("[storage]\nbackend='pgvector'\n[storage.postgres]\n{connection}schema='{schema}'\n[embedding]\nmodel='hypatia-contract-test'\ndimensions=3\n")).unwrap();
+    }
+    let mut mgr = ShelfManager::with_home(home.path().into()).unwrap();
+    mgr.connect(one.path(), Some("pg-a")).unwrap();
+    mgr.connect(two.path(), Some("pg-b")).unwrap();
+    contract(mgr.get_mut("pg-a").unwrap());
+    mgr.get("pg-b")
+        .unwrap()
+        .backend
+        .insert_knowledge("first", &Content::new("isolated"))
+        .unwrap();
+    assert_eq!(
+        mgr.get("pg-b")
+            .unwrap()
+            .backend
+            .get_knowledge("first")
+            .unwrap()
+            .unwrap()
+            .content
+            .data,
+        "isolated"
+    );
+    assert!(
+        mgr.get("default")
+            .unwrap()
+            .backend
+            .get_knowledge("first")
+            .unwrap()
+            .is_none()
+    );
+    let export = TempDir::new().unwrap();
+    mgr.export("pg-b", export.path()).unwrap();
+    assert!(!export.path().join("shelf.toml").exists());
+    for name in ["snapshot.json", "manifest.json"] {
+        assert!(
+            !std::fs::read_to_string(export.path().join(name))
+                .unwrap()
+                .contains(&direct_url)
+        );
+    }
+    for dir in [&one, &two] {
+        assert!(!dir.path().join("hypatia.sqlite").exists());
+        assert!(!dir.path().join("vectors").exists());
+    }
+    drop(mgr);
+    let mut client = postgres::Client::connect(
+        &std::env::var("HYPATIA_TEST_POSTGRES_URL").unwrap(),
+        postgres::NoTls,
+    )
+    .unwrap();
+    for schema in schemas {
+        client
+            .batch_execute(&format!("DROP SCHEMA \"{schema}\" CASCADE"))
+            .unwrap();
+    }
+}

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -43,17 +43,22 @@ fn run_benchmark() {
     println!("  Generating synthetic data...");
     let mut generator = BenchDataGenerator::new(config);
     generator.generate();
-    println!("  Generated {} knowledge, {} statements, {} needles",
-        generator.knowledge.len(), generator.statements.len(), generator.needles.len());
+    println!(
+        "  Generated {} knowledge, {} statements, {} needles",
+        generator.knowledge.len(),
+        generator.statements.len(),
+        generator.needles.len()
+    );
 
     // Setup shelf in temp directory
     let tmp_dir = tempfile::tempdir().expect("create temp dir");
     let shelf_path = tmp_dir.path().join("bench_shelf");
     // Hermetic home: never touch (or migrate!) the real ~/.hypatia shelf.
     let home = tempfile::tempdir().expect("create temp home");
-    let mut mgr = ShelfManager::with_home(home.path().to_path_buf())
-        .expect("create shelf manager");
-    let shelf_name = mgr.connect(&shelf_path, Some("bench")).expect("connect shelf");
+    let mut mgr = ShelfManager::with_home(home.path().to_path_buf()).expect("create shelf manager");
+    let shelf_name = mgr
+        .connect(&shelf_path, Some("bench"))
+        .expect("connect shelf");
 
     // ── Phase 1: Ingest ────────────────────────────────────────────
     println!("\n  Phase 1: Ingestion...");
@@ -68,7 +73,10 @@ fn run_benchmark() {
         svc.create(&entry.name, content).expect("create knowledge");
         knowledge_count += 1;
         if knowledge_count % 500 == 0 {
-            print!("    {knowledge_count}/{} knowledge entries\r", generator.knowledge.len());
+            print!(
+                "    {knowledge_count}/{} knowledge entries\r",
+                generator.knowledge.len()
+            );
         }
     }
     let knowledge_time = t0.elapsed();
@@ -80,10 +88,14 @@ fn run_benchmark() {
         let content = Content::new(&entry.data);
         let shelf = mgr.get_mut(&shelf_name).expect("get shelf");
         let mut svc = hypatia::service::StatementService::new(shelf);
-        svc.create(&key, content, None, None).expect("create statement");
+        svc.create(&key, content, None, None)
+            .expect("create statement");
         stmt_count += 1;
         if stmt_count % 1000 == 0 {
-            print!("    {stmt_count}/{} statements\r", generator.statements.len());
+            print!(
+                "    {stmt_count}/{} statements\r",
+                generator.statements.len()
+            );
         }
     }
     let statement_time = t1.elapsed();
@@ -92,8 +104,14 @@ fn run_benchmark() {
     let knowledge_per_sec = knowledge_count as f64 / knowledge_time.as_secs_f64();
     let statement_per_sec = stmt_count as f64 / statement_time.as_secs_f64();
 
-    println!("    Knowledge: {knowledge_count} entries in {:.2}s ({knowledge_per_sec:.0}/s)", knowledge_time.as_secs_f64());
-    println!("    Statements: {stmt_count} entries in {:.2}s ({statement_per_sec:.0}/s)", statement_time.as_secs_f64());
+    println!(
+        "    Knowledge: {knowledge_count} entries in {:.2}s ({knowledge_per_sec:.0}/s)",
+        knowledge_time.as_secs_f64()
+    );
+    println!(
+        "    Statements: {stmt_count} entries in {:.2}s ({statement_per_sec:.0}/s)",
+        statement_time.as_secs_f64()
+    );
     println!("    Total ingest: {:.2}s", total_ingest.as_secs_f64());
 
     // ── Phase 2: FTS Search Recall ─────────────────────────────────
@@ -129,7 +147,9 @@ fn run_benchmark() {
             }
         };
 
-        let found_names: Vec<String> = result.rows.iter()
+        let found_names: Vec<String> = result
+            .rows
+            .iter()
             .filter_map(|row| row.get("key").and_then(|v| v.as_str()).map(String::from))
             .collect();
 
@@ -149,9 +169,21 @@ fn run_benchmark() {
     let recall_at_10 = recall_hits_at_10 as f64 / needle_count as f64;
 
     println!("    Needle queries: {needle_count}");
-    println!("    Recall@1:  {:.1}% ({}/{needle_count})", recall_at_1 * 100.0, recall_hits_at_1);
-    println!("    Recall@5:  {:.1}% ({}/{needle_count})", recall_at_5 * 100.0, recall_hits_at_5);
-    println!("    Recall@10: {:.1}% ({}/{needle_count})", recall_at_10 * 100.0, recall_hits_at_10);
+    println!(
+        "    Recall@1:  {:.1}% ({}/{needle_count})",
+        recall_at_1 * 100.0,
+        recall_hits_at_1
+    );
+    println!(
+        "    Recall@5:  {:.1}% ({}/{needle_count})",
+        recall_at_5 * 100.0,
+        recall_hits_at_5
+    );
+    println!(
+        "    Recall@10: {:.1}% ({}/{needle_count})",
+        recall_at_10 * 100.0,
+        recall_hits_at_10
+    );
 
     // ── Phase 3: FTS Search Latency ────────────────────────────────
     println!("\n  Phase 3: FTS Search Latency...");
@@ -225,7 +257,11 @@ fn run_benchmark() {
     }
 
     let jse_stats = LatencyStats::from_durations(&jse_durations);
-    println!("    Queries: {} ({} unique × 3 runs)", jse_durations.len(), jse_queries.len());
+    println!(
+        "    Queries: {} ({} unique × 3 runs)",
+        jse_durations.len(),
+        jse_queries.len()
+    );
     println!("    p50: {:.0} µs", jse_stats.p50_us);
     println!("    p99: {:.0} µs", jse_stats.p99_us);
     println!("    max: {:.0} µs", jse_stats.max_us);
@@ -234,7 +270,10 @@ fn run_benchmark() {
     println!("\n{}", "═".repeat(58));
     println!("  SUMMARY");
     println!("{}", "═".repeat(58));
-    println!("  Ingest:    {:.0} knowledge/s, {:.0} statements/s", knowledge_per_sec, statement_per_sec);
+    println!(
+        "  Ingest:    {:.0} knowledge/s, {:.0} statements/s",
+        knowledge_per_sec, statement_per_sec
+    );
     println!("  Recall@1:  {:.1}%", recall_at_1 * 100.0);
     println!("  Recall@5:  {:.1}%", recall_at_5 * 100.0);
     println!("  Recall@10: {:.1}%", recall_at_10 * 100.0);

--- a/tests/bench_data.rs
+++ b/tests/bench_data.rs
@@ -18,13 +18,28 @@ pub struct ScaleConfig {
 
 impl ScaleConfig {
     pub fn small() -> Self {
-        Self { n_knowledge: 1_000, n_statements: 2_000, n_needles: 20, n_queries: 40 }
+        Self {
+            n_knowledge: 1_000,
+            n_statements: 2_000,
+            n_needles: 20,
+            n_queries: 40,
+        }
     }
     pub fn medium() -> Self {
-        Self { n_knowledge: 10_000, n_statements: 20_000, n_needles: 50, n_queries: 100 }
+        Self {
+            n_knowledge: 10_000,
+            n_statements: 20_000,
+            n_needles: 50,
+            n_queries: 100,
+        }
     }
     pub fn large() -> Self {
-        Self { n_knowledge: 50_000, n_statements: 100_000, n_needles: 100, n_queries: 200 }
+        Self {
+            n_knowledge: 50_000,
+            n_statements: 100_000,
+            n_needles: 100,
+            n_queries: 200,
+        }
     }
 
     pub fn from_name(name: &str) -> Self {
@@ -39,37 +54,107 @@ impl ScaleConfig {
 // ── Vocabulary banks ──────────────────────────────────────────────────
 
 const TECH_TERMS: &[&str] = &[
-    "authentication", "authorization", "middleware", "endpoint", "REST API",
-    "GraphQL", "WebSocket", "database migration", "ORM", "query optimization",
-    "caching strategy", "load balancer", "rate limiting", "pagination",
-    "serialization", "validation", "error handling", "logging framework",
-    "monitoring", "deployment pipeline", "CI/CD", "containerization",
-    "microservice", "event sourcing", "message queue", "pub/sub",
-    "connection pooling", "session management", "token refresh", "CORS",
-    "SSL termination", "health check", "circuit breaker", "retry logic",
-    "batch processing", "stream processing", "data pipeline", "ETL",
-    "feature flag", "A/B testing", "blue-green deployment", "canary release",
-    "vector database", "embedding model", "full text search", "inverted index",
-    "knowledge graph", "triple store", "semantic query", "structured data",
+    "authentication",
+    "authorization",
+    "middleware",
+    "endpoint",
+    "REST API",
+    "GraphQL",
+    "WebSocket",
+    "database migration",
+    "ORM",
+    "query optimization",
+    "caching strategy",
+    "load balancer",
+    "rate limiting",
+    "pagination",
+    "serialization",
+    "validation",
+    "error handling",
+    "logging framework",
+    "monitoring",
+    "deployment pipeline",
+    "CI/CD",
+    "containerization",
+    "microservice",
+    "event sourcing",
+    "message queue",
+    "pub/sub",
+    "connection pooling",
+    "session management",
+    "token refresh",
+    "CORS",
+    "SSL termination",
+    "health check",
+    "circuit breaker",
+    "retry logic",
+    "batch processing",
+    "stream processing",
+    "data pipeline",
+    "ETL",
+    "feature flag",
+    "A/B testing",
+    "blue-green deployment",
+    "canary release",
+    "vector database",
+    "embedding model",
+    "full text search",
+    "inverted index",
+    "knowledge graph",
+    "triple store",
+    "semantic query",
+    "structured data",
 ];
 
 const ENTITY_NAMES: &[&str] = &[
-    "Alice", "Bob", "Carol", "Dave", "Eve", "Frank", "Grace", "Heidi",
-    "Ivan", "Judy", "Karl", "Linda", "Mike", "Nina", "Oscar", "Pat",
-    "Quinn", "Rita", "Steve", "Tina", "Ursula", "Victor", "Wendy", "Xander",
+    "Alice", "Bob", "Carol", "Dave", "Eve", "Frank", "Grace", "Heidi", "Ivan", "Judy", "Karl",
+    "Linda", "Mike", "Nina", "Oscar", "Pat", "Quinn", "Rita", "Steve", "Tina", "Ursula", "Victor",
+    "Wendy", "Xander",
 ];
 
 const PREDICATES: &[&str] = &[
-    "works_on", "manages", "reports_to", "collaborates_with",
-    "created", "maintains", "uses", "depends_on", "replaced",
-    "reviewed", "deployed", "tested", "documented", "mentors", "leads",
-    "contributes_to", "is_a", "contains", "references", "integrates_with",
+    "works_on",
+    "manages",
+    "reports_to",
+    "collaborates_with",
+    "created",
+    "maintains",
+    "uses",
+    "depends_on",
+    "replaced",
+    "reviewed",
+    "deployed",
+    "tested",
+    "documented",
+    "mentors",
+    "leads",
+    "contributes_to",
+    "is_a",
+    "contains",
+    "references",
+    "integrates_with",
 ];
 
 const TAGS: &[&str] = &[
-    "backend", "frontend", "api", "database", "auth", "testing", "docs",
-    "config", "deployment", "models", "performance", "security", "monitoring",
-    "infrastructure", "benchmark", "rust", "python", "typescript", "go",
+    "backend",
+    "frontend",
+    "api",
+    "database",
+    "auth",
+    "testing",
+    "docs",
+    "config",
+    "deployment",
+    "models",
+    "performance",
+    "security",
+    "monitoring",
+    "infrastructure",
+    "benchmark",
+    "rust",
+    "python",
+    "typescript",
+    "go",
 ];
 
 const NEEDLE_TOPICS: &[&str] = &[
@@ -137,9 +222,15 @@ fn sanitize_fts_query(query: &str) -> String {
     // Replace FTS5 special characters with spaces, then collapse whitespace
     // FTS5 specials: : (column filter), " (phrase), * (prefix), ^ (beginning)
     // + (AND), - (NOT), ( ) (grouping), . (syntax error in some contexts)
-    let sanitized: String = query.chars()
+    let sanitized: String = query
+        .chars()
         .map(|c| {
-            matches!(c, ':' | '"' | '\'' | '*' | '^' | '+' | '-' | '(' | ')' | '.').then_some(' ').unwrap_or(c)
+            matches!(
+                c,
+                ':' | '"' | '\'' | '*' | '^' | '+' | '-' | '(' | ')' | '.'
+            )
+            .then_some(' ')
+            .unwrap_or(c)
         })
         .collect();
     let mut result = String::new();
@@ -205,14 +296,50 @@ impl BenchDataGenerator {
 
     fn random_sentence(&mut self) -> String {
         let n_terms = self.rng.random_range(3..=6);
-        let terms: Vec<&str> = self.pick_n(TECH_TERMS, n_terms).iter().map(|&t| *t).collect();
+        let terms: Vec<&str> = self
+            .pick_n(TECH_TERMS, n_terms)
+            .iter()
+            .map(|&t| *t)
+            .collect();
         let entity = *self.pick(ENTITY_NAMES);
         let templates = [
-            format!("{entity} discussed {} implementation with the team, focusing on {} patterns and {} best practices.", terms[0], terms.get(1).unwrap_or(&"design"), terms.get(2).unwrap_or(&"testing")),
-            format!("The {} module was refactored to improve {} performance. Key change: {} pipeline now uses {} for better throughput.", terms[0], terms.get(1).unwrap_or(&"system"), terms.get(2).unwrap_or(&"data"), terms.get(3).unwrap_or(&"async")),
-            format!("Bug report: {} fails when {} is null. Root cause identified as missing {} validation. Fixed by adding {} checks in the {} layer.", terms[0], terms.get(1).unwrap_or(&"input"), terms.get(2).unwrap_or(&"type"), terms.get(3).unwrap_or(&"boundary"), terms.get(4).unwrap_or(&"service")),
-            format!("Architecture decision: migrated from {} to {} for {} reasons. Performance improved by {}% after switching to {}-based {}.", terms[0], terms.get(1).unwrap_or(&"new system"), terms.get(2).unwrap_or(&"scalability"), self.rng.random_range(10..80), terms.get(3).unwrap_or(&"event"), terms.get(4).unwrap_or(&"processing")),
-            format!("Meeting notes: discussed {} with {entity}. Agreed to implement {} using {} approach. Deadline set for next sprint. Follow-up on {} integration required.", terms[0], terms.get(1).unwrap_or(&"feature"), terms.get(2).unwrap_or(&"modular"), terms.get(3).unwrap_or(&"system")),
+            format!(
+                "{entity} discussed {} implementation with the team, focusing on {} patterns and {} best practices.",
+                terms[0],
+                terms.get(1).unwrap_or(&"design"),
+                terms.get(2).unwrap_or(&"testing")
+            ),
+            format!(
+                "The {} module was refactored to improve {} performance. Key change: {} pipeline now uses {} for better throughput.",
+                terms[0],
+                terms.get(1).unwrap_or(&"system"),
+                terms.get(2).unwrap_or(&"data"),
+                terms.get(3).unwrap_or(&"async")
+            ),
+            format!(
+                "Bug report: {} fails when {} is null. Root cause identified as missing {} validation. Fixed by adding {} checks in the {} layer.",
+                terms[0],
+                terms.get(1).unwrap_or(&"input"),
+                terms.get(2).unwrap_or(&"type"),
+                terms.get(3).unwrap_or(&"boundary"),
+                terms.get(4).unwrap_or(&"service")
+            ),
+            format!(
+                "Architecture decision: migrated from {} to {} for {} reasons. Performance improved by {}% after switching to {}-based {}.",
+                terms[0],
+                terms.get(1).unwrap_or(&"new system"),
+                terms.get(2).unwrap_or(&"scalability"),
+                self.rng.random_range(10..80),
+                terms.get(3).unwrap_or(&"event"),
+                terms.get(4).unwrap_or(&"processing")
+            ),
+            format!(
+                "Meeting notes: discussed {} with {entity}. Agreed to implement {} using {} approach. Deadline set for next sprint. Follow-up on {} integration required.",
+                terms[0],
+                terms.get(1).unwrap_or(&"feature"),
+                terms.get(2).unwrap_or(&"modular"),
+                terms.get(3).unwrap_or(&"system")
+            ),
         ];
         templates[self.rng.random_range(0..templates.len())].clone()
     }
@@ -253,7 +380,9 @@ impl BenchDataGenerator {
             // (: is column filter, - is NOT, " is phrase, etc.)
             let query = sanitize_fts_query(&raw_query);
 
-            let content = format!("{needle_id}: {topic}. This is a unique planted needle for recall benchmarking at scale.");
+            let content = format!(
+                "{needle_id}: {topic}. This is a unique planted needle for recall benchmarking at scale."
+            );
 
             self.needles.push(Needle {
                 id: needle_id,
@@ -362,6 +491,11 @@ impl LatencyStats {
         let p99 = us[us.len() * 99 / 100];
         let max = *us.last().unwrap_or(&0);
         let min = *us.first().unwrap_or(&0);
-        Self { p50_us: p50, p99_us: p99, max_us: max, min_us: min }
+        Self {
+            p50_us: p50,
+            p99_us: p99,
+            max_us: max,
+            min_us: min,
+        }
     }
 }

--- a/tests/locomo.rs
+++ b/tests/locomo.rs
@@ -95,8 +95,7 @@ fn extract_sessions(conv_data: &ConversationData) -> Vec<(usize, String, Vec<Tur
                     .unwrap_or("unknown date")
                     .to_string();
 
-                let turns: Vec<Turn> = serde_json::from_value(value.clone())
-                    .unwrap_or_default();
+                let turns: Vec<Turn> = serde_json::from_value(value.clone()).unwrap_or_default();
 
                 sessions.push((session_num, date, turns));
             }
@@ -208,17 +207,18 @@ struct EvalResult {
 }
 
 fn compute_recall(top_keys: &[String], expected: &[String], k: usize) -> bool {
-    expected.iter().any(|exp| top_keys.iter().take(k).any(|k_| k_ == exp))
+    expected
+        .iter()
+        .any(|exp| top_keys.iter().take(k).any(|k_| k_ == exp))
 }
 
 // ── Main benchmark ───────────────────────────────────────────────────
 
 #[test]
 fn run_locomo_benchmark() {
-    let data_path =
-        env::var("LOCOMO_DATA").unwrap_or_else(|_| "locomo10.json".to_string());
-    let results_path = env::var("LOCOMO_RESULTS")
-        .unwrap_or_else(|_| "locomo_results.jsonl".to_string());
+    let data_path = env::var("LOCOMO_DATA").unwrap_or_else(|_| "locomo10.json".to_string());
+    let results_path =
+        env::var("LOCOMO_RESULTS").unwrap_or_else(|_| "locomo_results.jsonl".to_string());
 
     // Load LoCoMo data
     println!();
@@ -261,8 +261,7 @@ fn run_locomo_benchmark() {
 
     // Hermetic home: never touch (or migrate!) the real ~/.hypatia shelf.
     let home = tempfile::tempdir().expect("create temp home");
-    let mut mgr = ShelfManager::with_home(home.path().to_path_buf())
-        .expect("create shelf manager");
+    let mut mgr = ShelfManager::with_home(home.path().to_path_buf()).expect("create shelf manager");
     let shelf_name = mgr
         .connect(&shelf_path, Some("locomo"))
         .expect("connect shelf");
@@ -306,7 +305,11 @@ fn run_locomo_benchmark() {
             if let Some(summary) = conv.session_summary.get(&summary_key) {
                 if let Some(text) = summary.as_str() {
                     let name = format!("{sid}__summary_{session_num}");
-                    let tags = vec![sid.clone(), format!("session_{session_num}"), "summary".into()];
+                    let tags = vec![
+                        sid.clone(),
+                        format!("session_{session_num}"),
+                        "summary".into(),
+                    ];
                     let content = Content::new(text).with_tags(tags);
                     let shelf = mgr.get_mut(&shelf_name).expect("get shelf");
                     let mut svc = hypatia::service::KnowledgeService::new(shelf);
@@ -321,7 +324,11 @@ fn run_locomo_benchmark() {
             if let Some(events) = conv.event_summary.get(&event_key) {
                 let name = format!("{sid}__events_{session_num}");
                 let text = serde_json::to_string(events).unwrap_or_default();
-                let tags = vec![sid.clone(), format!("session_{session_num}"), "events".into()];
+                let tags = vec![
+                    sid.clone(),
+                    format!("session_{session_num}"),
+                    "events".into(),
+                ];
                 let content = Content::new(&text).with_tags(tags);
                 let shelf = mgr.get_mut(&shelf_name).expect("get shelf");
                 let mut svc = hypatia::service::KnowledgeService::new(shelf);
@@ -335,7 +342,11 @@ fn run_locomo_benchmark() {
             if let Some(obs) = conv.observation.get(&obs_key) {
                 let name = format!("{sid}__obs_{session_num}");
                 let text = serde_json::to_string(obs).unwrap_or_default();
-                let tags = vec![sid.clone(), format!("session_{session_num}"), "observation".into()];
+                let tags = vec![
+                    sid.clone(),
+                    format!("session_{session_num}"),
+                    "observation".into(),
+                ];
                 let content = Content::new(&text).with_tags(tags);
                 let shelf = mgr.get_mut(&shelf_name).expect("get shelf");
                 let mut svc = hypatia::service::KnowledgeService::new(shelf);
@@ -357,7 +368,10 @@ fn run_locomo_benchmark() {
     );
 
     // ── Phase 2: Search (FTS + Vector) ──────────────────────────────
-    println!("\n  Phase 2: Running searches for {} QA pairs...", non_adversarial);
+    println!(
+        "\n  Phase 2: Running searches for {} QA pairs...",
+        non_adversarial
+    );
     println!("    Methods: FTS (BM25) + Vector (cosine similarity)");
 
     let shelf = mgr.get(&shelf_name).expect("get shelf");
@@ -398,7 +412,8 @@ fn run_locomo_benchmark() {
 
             let (fts_top_keys, fts_r1, fts_r5, fts_r10, fts_lat) = {
                 let t = Instant::now();
-                let result = shelf.execute_search(&fts_query, &fts_opts)
+                let result = shelf
+                    .execute_search(&fts_query, &fts_opts)
                     .unwrap_or_else(|e| {
                         eprintln!("    WARN: FTS search failed for '{}': {}", qa.question, e);
                         hypatia::model::QueryResult::new(Vec::new())
@@ -515,26 +530,52 @@ fn run_locomo_benchmark() {
     for r in &eval_results {
         let fts = fts_by_cat.entry(r.category).or_insert((0, 0, 0, 0));
         fts.0 += 1;
-        if r.fts_recall_at_1 { fts.1 += 1; }
-        if r.fts_recall_at_5 { fts.2 += 1; }
-        if r.fts_recall_at_10 { fts.3 += 1; }
+        if r.fts_recall_at_1 {
+            fts.1 += 1;
+        }
+        if r.fts_recall_at_5 {
+            fts.2 += 1;
+        }
+        if r.fts_recall_at_10 {
+            fts.3 += 1;
+        }
 
-        if let (Some(vr1), Some(vr5), Some(vr10)) = (r.vec_recall_at_1, r.vec_recall_at_5, r.vec_recall_at_10) {
+        if let (Some(vr1), Some(vr5), Some(vr10)) =
+            (r.vec_recall_at_1, r.vec_recall_at_5, r.vec_recall_at_10)
+        {
             let vec = vec_by_cat.entry(r.category).or_insert((0, 0, 0, 0));
             vec.0 += 1;
-            if vr1 { vec.1 += 1; }
-            if vr5 { vec.2 += 1; }
-            if vr10 { vec.3 += 1; }
+            if vr1 {
+                vec.1 += 1;
+            }
+            if vr5 {
+                vec.2 += 1;
+            }
+            if vr10 {
+                vec.3 += 1;
+            }
         }
     }
 
     fts_latencies.sort();
     vec_latencies.sort();
 
-    let fts_p50 = fts_latencies.get(fts_latencies.len() / 2).copied().unwrap_or(0);
-    let fts_p99 = fts_latencies.get(fts_latencies.len() * 99 / 100).copied().unwrap_or(0);
-    let vec_p50 = vec_latencies.get(vec_latencies.len() / 2).copied().unwrap_or(0);
-    let vec_p99 = vec_latencies.get(vec_latencies.len() * 99 / 100).copied().unwrap_or(0);
+    let fts_p50 = fts_latencies
+        .get(fts_latencies.len() / 2)
+        .copied()
+        .unwrap_or(0);
+    let fts_p99 = fts_latencies
+        .get(fts_latencies.len() * 99 / 100)
+        .copied()
+        .unwrap_or(0);
+    let vec_p50 = vec_latencies
+        .get(vec_latencies.len() / 2)
+        .copied()
+        .unwrap_or(0);
+    let vec_p99 = vec_latencies
+        .get(vec_latencies.len() * 99 / 100)
+        .copied()
+        .unwrap_or(0);
 
     // ── Summary ──────────────────────────────────────────────────────
     println!("\n\n{}", "═".repeat(70));
@@ -544,18 +585,31 @@ fn run_locomo_benchmark() {
     println!("  QA evaluated:   {eval_count}");
     println!();
 
-    let cat_names = [(4u32, "Single-hop"), (1, "Multi-hop"), (2, "Temporal"), (3, "Open-domain")];
+    let cat_names = [
+        (4u32, "Single-hop"),
+        (1, "Multi-hop"),
+        (2, "Temporal"),
+        (3, "Open-domain"),
+    ];
 
     // FTS table
     println!("  FTS (BM25, top-K)");
-    println!("  {:20} {:>5} {:>8} {:>8} {:>8}", "Category", "N", "R@1", "R@5", "R@10");
+    println!(
+        "  {:20} {:>5} {:>8} {:>8} {:>8}",
+        "Category", "N", "R@1", "R@5", "R@10"
+    );
     println!("  {}", "-".repeat(53));
     let mut fts_total = (0usize, 0usize, 0usize, 0usize);
     for (cat, name) in &cat_names {
         if let Some(&(n, r1, r5, r10)) = fts_by_cat.get(cat) {
-            fts_total.0 += n; fts_total.1 += r1; fts_total.2 += r5; fts_total.3 += r10;
-            println!("  {:20} {:>5} {:>7.1}% {:>7.1}% {:>7.1}%",
-                name, n,
+            fts_total.0 += n;
+            fts_total.1 += r1;
+            fts_total.2 += r5;
+            fts_total.3 += r10;
+            println!(
+                "  {:20} {:>5} {:>7.1}% {:>7.1}% {:>7.1}%",
+                name,
+                n,
                 r1 as f64 / n as f64 * 100.0,
                 r5 as f64 / n as f64 * 100.0,
                 r10 as f64 / n as f64 * 100.0,
@@ -563,8 +617,10 @@ fn run_locomo_benchmark() {
         }
     }
     println!("  {}", "-".repeat(53));
-    println!("  {:20} {:>5} {:>7.1}% {:>7.1}% {:>7.1}%",
-        "OVERALL", fts_total.0,
+    println!(
+        "  {:20} {:>5} {:>7.1}% {:>7.1}% {:>7.1}%",
+        "OVERALL",
+        fts_total.0,
         fts_total.1 as f64 / fts_total.0 as f64 * 100.0,
         fts_total.2 as f64 / fts_total.0 as f64 * 100.0,
         fts_total.3 as f64 / fts_total.0 as f64 * 100.0,
@@ -574,14 +630,22 @@ fn run_locomo_benchmark() {
     if has_model && !vec_by_cat.is_empty() {
         println!();
         println!("  Vector (cosine similarity, top-K)");
-        println!("  {:20} {:>5} {:>8} {:>8} {:>8}", "Category", "N", "R@1", "R@5", "R@10");
+        println!(
+            "  {:20} {:>5} {:>8} {:>8} {:>8}",
+            "Category", "N", "R@1", "R@5", "R@10"
+        );
         println!("  {}", "-".repeat(53));
         let mut vec_total = (0usize, 0usize, 0usize, 0usize);
         for (cat, name) in &cat_names {
             if let Some(&(n, r1, r5, r10)) = vec_by_cat.get(cat) {
-                vec_total.0 += n; vec_total.1 += r1; vec_total.2 += r5; vec_total.3 += r10;
-                println!("  {:20} {:>5} {:>7.1}% {:>7.1}% {:>7.1}%",
-                    name, n,
+                vec_total.0 += n;
+                vec_total.1 += r1;
+                vec_total.2 += r5;
+                vec_total.3 += r10;
+                println!(
+                    "  {:20} {:>5} {:>7.1}% {:>7.1}% {:>7.1}%",
+                    name,
+                    n,
                     r1 as f64 / n as f64 * 100.0,
                     r5 as f64 / n as f64 * 100.0,
                     r10 as f64 / n as f64 * 100.0,
@@ -590,8 +654,10 @@ fn run_locomo_benchmark() {
         }
         println!("  {}", "-".repeat(53));
         if vec_total.0 > 0 {
-            println!("  {:20} {:>5} {:>7.1}% {:>7.1}% {:>7.1}%",
-                "OVERALL", vec_total.0,
+            println!(
+                "  {:20} {:>5} {:>7.1}% {:>7.1}% {:>7.1}%",
+                "OVERALL",
+                vec_total.0,
                 vec_total.1 as f64 / vec_total.0 as f64 * 100.0,
                 vec_total.2 as f64 / vec_total.0 as f64 * 100.0,
                 vec_total.3 as f64 / vec_total.0 as f64 * 100.0,
@@ -600,26 +666,42 @@ fn run_locomo_benchmark() {
             // Delta
             println!();
             println!("  IMPROVEMENT (Vector vs FTS)");
-            println!("  {:20} {:>8} {:>8} {:>8}", "Category", "Δ R@1", "Δ R@5", "Δ R@10");
+            println!(
+                "  {:20} {:>8} {:>8} {:>8}",
+                "Category", "Δ R@1", "Δ R@5", "Δ R@10"
+            );
             println!("  {}", "-".repeat(48));
             for (cat, name) in &cat_names {
-                let fts = fts_by_cat.get(cat).copied().unwrap_or((0,0,0,0));
-                let vec_ = vec_by_cat.get(cat).copied().unwrap_or((0,0,0,0));
+                let fts = fts_by_cat.get(cat).copied().unwrap_or((0, 0, 0, 0));
+                let vec_ = vec_by_cat.get(cat).copied().unwrap_or((0, 0, 0, 0));
                 if fts.0 > 0 && vec_.0 > 0 {
                     let d1 = vec_.1 as f64 / vec_.0 as f64 - fts.1 as f64 / fts.0 as f64;
                     let d5 = vec_.2 as f64 / vec_.0 as f64 - fts.2 as f64 / fts.0 as f64;
                     let d10 = vec_.3 as f64 / vec_.0 as f64 - fts.3 as f64 / fts.0 as f64;
-                    println!("  {:20} {:>+7.1}% {:>+7.1}% {:>+7.1}%",
-                        name, d1 * 100.0, d5 * 100.0, d10 * 100.0);
+                    println!(
+                        "  {:20} {:>+7.1}% {:>+7.1}% {:>+7.1}%",
+                        name,
+                        d1 * 100.0,
+                        d5 * 100.0,
+                        d10 * 100.0
+                    );
                 }
             }
             if fts_total.0 > 0 && vec_total.0 > 0 {
-                let d1 = vec_total.1 as f64 / vec_total.0 as f64 - fts_total.1 as f64 / fts_total.0 as f64;
-                let d5 = vec_total.2 as f64 / vec_total.0 as f64 - fts_total.2 as f64 / fts_total.0 as f64;
-                let d10 = vec_total.3 as f64 / vec_total.0 as f64 - fts_total.3 as f64 / fts_total.0 as f64;
+                let d1 = vec_total.1 as f64 / vec_total.0 as f64
+                    - fts_total.1 as f64 / fts_total.0 as f64;
+                let d5 = vec_total.2 as f64 / vec_total.0 as f64
+                    - fts_total.2 as f64 / fts_total.0 as f64;
+                let d10 = vec_total.3 as f64 / vec_total.0 as f64
+                    - fts_total.3 as f64 / fts_total.0 as f64;
                 println!("  {}", "-".repeat(48));
-                println!("  {:20} {:>+7.1}% {:>+7.1}% {:>+7.1}%",
-                    "OVERALL", d1 * 100.0, d5 * 100.0, d10 * 100.0);
+                println!(
+                    "  {:20} {:>+7.1}% {:>+7.1}% {:>+7.1}%",
+                    "OVERALL",
+                    d1 * 100.0,
+                    d5 * 100.0,
+                    d10 * 100.0
+                );
             }
         }
     }

--- a/tests/longmemeval.rs
+++ b/tests/longmemeval.rs
@@ -18,7 +18,7 @@ use serde::Deserialize;
 use serde_json::json;
 
 use hypatia::model::{Content, QueryTarget, SearchOpts};
-use hypatia::storage::{sanitize_fts_query, ShelfManager, Storage};
+use hypatia::storage::{ShelfManager, Storage, sanitize_fts_query};
 
 // ── Helper: accept both string and integer for "answer" field ────────
 
@@ -241,11 +241,10 @@ fn run_longmemeval_benchmark() {
         panic!("Data file not found");
     });
     let reader = BufReader::new(file);
-    let instances: Vec<EvalInstance> =
-        serde_json::from_reader(reader).unwrap_or_else(|e| {
-            eprintln!("  ERROR: Failed to parse {data_path}: {e}");
-            panic!("Parse error");
-        });
+    let instances: Vec<EvalInstance> = serde_json::from_reader(reader).unwrap_or_else(|e| {
+        eprintln!("  ERROR: Failed to parse {data_path}: {e}");
+        panic!("Parse error");
+    });
 
     // Support subset via LONGMEMEVAL_MAX_QUESTIONS env var
     let max_questions: usize = env::var("LONGMEMEVAL_MAX_QUESTIONS")
@@ -297,8 +296,7 @@ fn run_longmemeval_benchmark() {
 
     // Hermetic home: never touch (or migrate!) the real ~/.hypatia shelf.
     let home = tempfile::tempdir().expect("create temp home");
-    let mut mgr = ShelfManager::with_home(home.path().to_path_buf())
-        .expect("create shelf manager");
+    let mut mgr = ShelfManager::with_home(home.path().to_path_buf()).expect("create shelf manager");
     let shelf_name = mgr
         .connect(&shelf_path, Some("longmemeval"))
         .expect("connect shelf");
@@ -419,7 +417,10 @@ fn run_longmemeval_benchmark() {
             let result = shelf
                 .execute_search(&fts_query, &fts_opts)
                 .unwrap_or_else(|e| {
-                    eprintln!("    WARN: FTS search failed for '{:?}': {}", inst.question, e);
+                    eprintln!(
+                        "    WARN: FTS search failed for '{:?}': {}",
+                        inst.question, e
+                    );
                     hypatia::model::QueryResult::new(Vec::new())
                 });
             let lat = t.elapsed().as_micros() as u64;
@@ -545,17 +546,33 @@ fn run_longmemeval_benchmark() {
         let fts_r5 = compute_session_recall(&r.fts_retrieved_sessions, expected_sessions, 5);
         let fts_r10 = compute_session_recall(&r.fts_retrieved_sessions, expected_sessions, 10);
 
-        let fts_type = fts_by_type.entry(r.question_type.clone()).or_insert((0, 0, 0, 0));
+        let fts_type = fts_by_type
+            .entry(r.question_type.clone())
+            .or_insert((0, 0, 0, 0));
         fts_type.0 += 1;
-        if fts_r1 { fts_type.1 += 1; }
-        if fts_r5 { fts_type.2 += 1; }
-        if fts_r10 { fts_type.3 += 1; }
+        if fts_r1 {
+            fts_type.1 += 1;
+        }
+        if fts_r5 {
+            fts_type.2 += 1;
+        }
+        if fts_r10 {
+            fts_type.3 += 1;
+        }
 
-        let fts_ab = fts_by_ability.entry(r.ability.clone()).or_insert((0, 0, 0, 0));
+        let fts_ab = fts_by_ability
+            .entry(r.ability.clone())
+            .or_insert((0, 0, 0, 0));
         fts_ab.0 += 1;
-        if fts_r1 { fts_ab.1 += 1; }
-        if fts_r5 { fts_ab.2 += 1; }
-        if fts_r10 { fts_ab.3 += 1; }
+        if fts_r1 {
+            fts_ab.1 += 1;
+        }
+        if fts_r5 {
+            fts_ab.2 += 1;
+        }
+        if fts_r10 {
+            fts_ab.3 += 1;
+        }
 
         // Vector
         if let Some(ref vec_sessions) = r.vec_retrieved_sessions {
@@ -563,29 +580,51 @@ fn run_longmemeval_benchmark() {
             let vec_r5 = compute_session_recall(vec_sessions, expected_sessions, 5);
             let vec_r10 = compute_session_recall(vec_sessions, expected_sessions, 10);
 
-            let vec_type = vec_by_type.entry(r.question_type.clone()).or_insert((0, 0, 0, 0));
+            let vec_type = vec_by_type
+                .entry(r.question_type.clone())
+                .or_insert((0, 0, 0, 0));
             vec_type.0 += 1;
-            if vec_r1 { vec_type.1 += 1; }
-            if vec_r5 { vec_type.2 += 1; }
-            if vec_r10 { vec_type.3 += 1; }
+            if vec_r1 {
+                vec_type.1 += 1;
+            }
+            if vec_r5 {
+                vec_type.2 += 1;
+            }
+            if vec_r10 {
+                vec_type.3 += 1;
+            }
 
-            let vec_ab = vec_by_ability.entry(r.ability.clone()).or_insert((0, 0, 0, 0));
+            let vec_ab = vec_by_ability
+                .entry(r.ability.clone())
+                .or_insert((0, 0, 0, 0));
             vec_ab.0 += 1;
-            if vec_r1 { vec_ab.1 += 1; }
-            if vec_r5 { vec_ab.2 += 1; }
-            if vec_r10 { vec_ab.3 += 1; }
+            if vec_r1 {
+                vec_ab.1 += 1;
+            }
+            if vec_r5 {
+                vec_ab.2 += 1;
+            }
+            if vec_r10 {
+                vec_ab.3 += 1;
+            }
         }
     }
 
     fts_latencies.sort();
     vec_latencies.sort();
 
-    let fts_p50 = fts_latencies.get(fts_latencies.len() / 2).copied().unwrap_or(0);
+    let fts_p50 = fts_latencies
+        .get(fts_latencies.len() / 2)
+        .copied()
+        .unwrap_or(0);
     let fts_p99 = fts_latencies
         .get(fts_latencies.len() * 99 / 100)
         .copied()
         .unwrap_or(0);
-    let vec_p50 = vec_latencies.get(vec_latencies.len() / 2).copied().unwrap_or(0);
+    let vec_p50 = vec_latencies
+        .get(vec_latencies.len() / 2)
+        .copied()
+        .unwrap_or(0);
     let vec_p99 = vec_latencies
         .get(vec_latencies.len() * 99 / 100)
         .copied()
@@ -602,7 +641,10 @@ fn run_longmemeval_benchmark() {
 
     // By ability
     println!("  RETRIEVAL — By Ability (session-level, excl. abstention)");
-    println!("  {:25} {:>5} {:>8} {:>8} {:>8}", "Ability", "N", "R@1", "R@5", "R@10");
+    println!(
+        "  {:25} {:>5} {:>8} {:>8} {:>8}",
+        "Ability", "N", "R@1", "R@5", "R@10"
+    );
     println!("  {}", "─".repeat(58));
 
     let ability_order = [
@@ -693,6 +735,8 @@ fn run_longmemeval_benchmark() {
     }
     println!("{}", "═".repeat(70));
     println!("\n  Results saved to: {results_path}");
-    println!("  Next: python3 scripts/longmemeval_eval.py --results {results_path} --retrieval-only");
+    println!(
+        "  Next: python3 scripts/longmemeval_eval.py --results {results_path} --retrieval-only"
+    );
     println!();
 }

--- a/tests/postgres_store.rs
+++ b/tests/postgres_store.rs
@@ -1,0 +1,512 @@
+#![cfg(feature = "postgres-backend")]
+//! Explicit live PostgreSQL tests: run with HYPATIA_TEST_POSTGRES_URL set and --ignored.
+//! Missing configuration is a failure, never a successful silent skip.
+use hypatia::{
+    embedding::EmbeddingConfig,
+    model::{Content, SearchOpts, StatementKey},
+    storage::{
+        postgres_store::PgStore,
+        settings::{PostgresSettings, ShelfSettings, VectorSettings},
+    },
+};
+use postgres::{Client, NoTls};
+use serde_json::json;
+use std::sync::atomic::{AtomicU64, Ordering};
+#[test]
+fn invalid_direct_url_does_not_echo_credentials() {
+    let settings = ShelfSettings::parse(
+        "[storage]\nbackend='pgvector'\n[storage.postgres]\nschema='redaction_test'\nurl='postgres://user:secret-test-password@localhost/db?sslmode=unsupported'\n[embedding]\nmodel='test-model'\n",
+        std::path::Path::new("."),
+    ).unwrap();
+    let err = PgStore::open(
+        settings.storage.postgres.as_ref().unwrap(),
+        &settings.storage.vector,
+        &settings.embedding,
+    )
+    .err()
+    .unwrap();
+    assert!(
+        err.to_string()
+            .contains("Invalid PostgreSQL connection configuration")
+    );
+    assert!(!format!("{err:?}").contains("secret-test-password"));
+}
+
+static NEXT: AtomicU64 = AtomicU64::new(0);
+struct Fixture {
+    config: PostgresSettings,
+    embedding: EmbeddingConfig,
+    vector: VectorSettings,
+}
+impl Fixture {
+    fn new(index: &str) -> Self {
+        std::env::var("HYPATIA_TEST_POSTGRES_URL").expect("set HYPATIA_TEST_POSTGRES_URL to a disposable PostgreSQL database with pgvector installed");
+        let settings = ShelfSettings::parse(
+            "[embedding]\nprovider='remote'\napi_model='pg-store-test'\ndimensions=3",
+            std::path::Path::new("."),
+        )
+        .unwrap();
+        Self {
+            config: PostgresSettings {
+                url_env: Some("HYPATIA_TEST_POSTGRES_URL".into()),
+                url: None,
+                schema: format!(
+                    "pgstore_test_{}_{}",
+                    std::process::id(),
+                    NEXT.fetch_add(1, Ordering::Relaxed)
+                ),
+                connect_timeout_seconds: 5,
+                statement_timeout_ms: 10000,
+            },
+            embedding: settings.embedding,
+            vector: VectorSettings {
+                index: index.into(),
+                metric: "cosine".into(),
+            },
+        }
+    }
+    fn open(&self) -> PgStore {
+        PgStore::open(&self.config, &self.vector, &self.embedding).unwrap()
+    }
+    fn admin(&self) -> Client {
+        Client::connect(&std::env::var("HYPATIA_TEST_POSTGRES_URL").unwrap(), NoTls).unwrap()
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if let Ok(url) = std::env::var("HYPATIA_TEST_POSTGRES_URL") {
+            if let Ok(mut c) = Client::connect(&url, NoTls) {
+                let _ = c.batch_execute(&format!(
+                    "DROP SCHEMA IF EXISTS \"{}\" CASCADE",
+                    self.config.schema
+                ));
+            }
+        }
+    }
+}
+#[test]
+#[ignore = "requires a disposable PostgreSQL database with pgvector"]
+fn crud_versions_fts_vectors_and_isolation() {
+    let f = Fixture::new("hnsw");
+    let a = f.open();
+    let b = f.open();
+    let v1 = a
+        .insert_knowledge("stable", &Content::new("oldword 北京知识图谱"))
+        .unwrap();
+    let id = a.doc_id_by_key("knowledge", "stable").unwrap().unwrap();
+    assert!(
+        b.install_embedding("knowledge", "stable", v1, &[1., 0., 0.])
+            .unwrap()
+    );
+    let v2 = a
+        .update_knowledge("stable", &Content::new("newword 北京知识图谱"))
+        .unwrap();
+    assert_ne!(v1, v2);
+    assert_eq!(a.embedding_row_count("knowledge").unwrap(), 0);
+    assert!(
+        !b.install_embedding("knowledge", "stable", v1, &[1., 0., 0.])
+            .unwrap()
+    );
+    assert_eq!(a.doc_id_by_key("knowledge", "stable").unwrap(), Some(id));
+    assert!(
+        a.search("oldword", &SearchOpts::default())
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        a.search("newword", &SearchOpts::default()).unwrap().len(),
+        1
+    );
+    assert_eq!(a.search("北京", &SearchOpts::default()).unwrap().len(), 1);
+    assert_eq!(
+        a.search("missing OR newword", &SearchOpts::default())
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        a.search("newword AND 北京", &SearchOpts::default())
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(a.search("newword", &SearchOpts::default()).unwrap()[0].rank < 0.0);
+    assert!(
+        a.install_embedding("knowledge", "stable", v2, &[1., 0., 0.])
+            .unwrap()
+    );
+    assert!(
+        a.install_embedding("knowledge", "stable", v2, &[0., 0., 0.])
+            .is_err()
+    );
+    assert!(
+        a.install_embedding("knowledge", "stable", v2, &[f32::NAN, 0., 1.])
+            .is_err()
+    );
+    assert!(
+        a.install_embedding("knowledge", "stable", v2, &[1., 0.])
+            .is_err()
+    );
+    let other = a
+        .insert_knowledge("opposite", &Content::new("other"))
+        .unwrap();
+    a.install_embedding("knowledge", "opposite", other, &[-1., 0., 0.])
+        .unwrap();
+    let hits = b.vector_search_knowledge(&[1., 0., 0.], 2).unwrap();
+    assert_eq!(hits[0].0, "stable");
+    assert!(hits[0].2.abs() < 1e-6);
+    assert!((hits[1].2 - 2.0).abs() < 1e-6);
+    a.delete_knowledge("stable").unwrap();
+    let v3 = a
+        .insert_knowledge("stable", &Content::new("recreated"))
+        .unwrap();
+    assert_ne!(v2, v3);
+    assert!(
+        !b.install_embedding("knowledge", "stable", v2, &[1., 0., 0.])
+            .unwrap()
+    );
+    assert_ne!(a.doc_id_by_key("knowledge", "stable").unwrap(), Some(id));
+    let isolated = Fixture::new("none");
+    assert!(isolated.open().get_knowledge("stable").unwrap().is_none());
+    assert_eq!(
+        a.missing_embeddings("knowledge", None, 1).unwrap()[0].0,
+        "stable"
+    );
+    assert!(
+        a.missing_embeddings("knowledge", Some("stable"), 1)
+            .unwrap()
+            .is_empty()
+    );
+    a.rebuild_indexes().unwrap();
+    assert_eq!(
+        a.search("recreated", &SearchOpts::default()).unwrap().len(),
+        1
+    );
+}
+#[test]
+#[ignore = "requires a disposable PostgreSQL database with pgvector"]
+fn graph_native_parameters_payload_and_snapshots() {
+    let f = Fixture::new("none");
+    let a = f.open();
+    let content = Content::new(r#"{"n":3,"tokens":[1e-7,"x"]}"#);
+    a.insert_knowledge("json", &content).unwrap();
+    let sql = format!(
+        "SELECT name,content,created_at FROM \"{}\".knowledge WHERE payload->>'n'=$1::text AND $2::float8=3 AND $3::bool AND $4::int4=4 LIMIT $5::int8",
+        f.config.schema
+    );
+    assert_eq!(
+        a.query_knowledge(
+            &sql,
+            vec![json!("3"), json!(3), json!(true), json!(4), json!(10)]
+        )
+        .unwrap()[0]
+            .content,
+        content
+    );
+    assert!(
+        a.query_knowledge(
+            &sql,
+            vec![
+                json!("3"),
+                json!("not number"),
+                json!(true),
+                json!(4),
+                json!(10)
+            ]
+        )
+        .is_err()
+    );
+    let dt =
+        chrono::NaiveDateTime::parse_from_str("2024-01-02 03:04:05", "%Y-%m-%d %H:%M:%S").unwrap();
+    let ab = StatementKey::new("a", "r", "b");
+    let bc = StatementKey::new("b", "r", "c");
+    let ca = StatementKey::new("c", "r", "a");
+    let token = a
+        .insert_statement(&ab, &Content::new("edge"), Some(dt), None)
+        .unwrap();
+    a.install_embedding("statement", &ab.to_csv_key(), token, &[0., 1., 0.])
+        .unwrap();
+    a.insert_statement(&bc, &Content::new("edge2"), None, None)
+        .unwrap();
+    a.insert_statement(&ca, &Content::new("cycle"), None, None)
+        .unwrap();
+    assert_eq!(a.query_khop("a", Some("r"), 2).unwrap().len(), 2);
+    assert_eq!(a.query_khop("a", None, 10).unwrap().len(), 3);
+    assert!(a.query_khop("a", None, 0).unwrap().is_empty());
+    assert_eq!(a.get_statement(&ab).unwrap().unwrap().tr_start, Some(dt));
+    let snap = a.snapshot().unwrap();
+    let dest = Fixture::new("none");
+    let target = dest.open();
+    target.import_snapshot(&snap).unwrap();
+    assert_eq!(target.snapshot().unwrap(), snap);
+    assert!(target.import_snapshot(&snap).is_err());
+    // Database rejects NUL text after the first valid record; whole import rolls back.
+    let rollback = Fixture::new("none");
+    let empty = rollback.open();
+    let mut bad = snap.clone();
+    bad.knowledge.push(snap.knowledge[0].clone());
+    bad.knowledge.last_mut().unwrap().knowledge.name = "bad\0key".into();
+    assert!(empty.import_snapshot(&bad).is_err());
+    assert!(empty.snapshot().unwrap().knowledge.is_empty());
+    assert!(empty.snapshot().unwrap().statements.is_empty());
+    let mut wrong = snap.clone();
+    wrong.embedding.as_mut().unwrap().model = "wrong-model".into();
+    assert!(empty.import_snapshot(&wrong).is_err());
+}
+#[test]
+#[ignore = "requires a disposable PostgreSQL database with pgvector"]
+fn metadata_validation_and_concurrent_initialization() {
+    let f = Fixture::new("hnsw");
+    std::thread::scope(|scope| {
+        let threads: Vec<_> = (0..4)
+            .map(|_| {
+                scope.spawn(|| {
+                    drop(f.open());
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+    });
+    let a = f.open();
+    let mut changed = f.embedding.clone();
+    changed.remote.dimensions = 4;
+    assert!(PgStore::open(&f.config, &f.vector, &changed).is_err());
+    changed = f.embedding.clone();
+    changed.model_identity = "different-provider-model".into();
+    assert!(PgStore::open(&f.config, &f.vector, &changed).is_err());
+    let mut admin = f.admin();
+    admin
+        .batch_execute(&format!(
+            "ALTER TABLE \"{}\".knowledge ALTER COLUMN embedding TYPE public.vector(4)",
+            f.config.schema
+        ))
+        .unwrap();
+    assert!(PgStore::open(&f.config, &f.vector, &f.embedding).is_err());
+    admin
+        .batch_execute(&format!(
+            "ALTER TABLE \"{}\".knowledge ALTER COLUMN embedding TYPE public.vector(3)",
+            f.config.schema
+        ))
+        .unwrap();
+    admin
+        .batch_execute(&format!(
+            "ALTER TABLE \"{}\".knowledge DROP COLUMN tokens",
+            f.config.schema
+        ))
+        .unwrap();
+    assert!(PgStore::open(&f.config, &f.vector, &f.embedding).is_err());
+    drop(a);
+    let mut hnsw = f.embedding.clone();
+    hnsw.remote.dimensions = 2001;
+    assert!(PgStore::open(&f.config, &f.vector, &hnsw).is_err());
+}
+
+#[test]
+#[ignore = "requires a disposable PostgreSQL database with pgvector"]
+fn concurrent_embedding_install_cannot_survive_content_update() {
+    let f = Fixture::new("none");
+    let store = f.open();
+    for iteration in 0..16 {
+        let key = format!("race-{iteration}");
+        let token = store.insert_knowledge(&key, &Content::new("old")).unwrap();
+        let barrier = std::sync::Barrier::new(2);
+        std::thread::scope(|scope| {
+            let install = scope.spawn(|| {
+                let c = f.open();
+                barrier.wait();
+                c.install_embedding("knowledge", &key, token, &[1., 0., 0.])
+                    .unwrap()
+            });
+            let update = scope.spawn(|| {
+                let c = f.open();
+                barrier.wait();
+                c.update_knowledge(&key, &Content::new("new")).unwrap()
+            });
+            install.join().unwrap();
+            update.join().unwrap();
+        });
+        assert_eq!(
+            store.get_knowledge(&key).unwrap().unwrap().content.data,
+            "new"
+        );
+        assert_eq!(store.embedding_row_count("knowledge").unwrap(), 0);
+    }
+}
+
+#[test]
+#[ignore = "requires a disposable PostgreSQL database with pgvector"]
+fn connection_and_statement_timeouts_are_explicit_errors() {
+    let mut f = Fixture::new("none");
+    if std::env::var("HYPATIA_PG_FAULT_SCENARIO").as_deref() == Ok("unreachable") {
+        f.config.connect_timeout_seconds = 1;
+        assert!(PgStore::open(&f.config, &f.vector, &f.embedding).is_err());
+        return;
+    }
+    f.config.statement_timeout_ms = 25;
+    let store = f.open();
+    store
+        .insert_knowledge("slow", &Content::new("data"))
+        .unwrap();
+    let result=store.query_knowledge(&format!("SELECT name,content,created_at FROM \"{}\".knowledge CROSS JOIN pg_catalog.pg_sleep(0.2)",f.config.schema),vec![]);
+    assert!(result.unwrap_err().to_string().contains("57014"));
+    assert!(store.get_knowledge("slow").unwrap().is_some());
+    run_fault_child(
+        "connection_and_statement_timeouts_are_explicit_errors",
+        "unreachable",
+        &test_connection(None, None, Some(1)),
+    );
+}
+
+#[test]
+#[ignore = "requires a disposable PostgreSQL database with pgvector"]
+fn representative_1024_dimension_hnsw_and_exact_plans() {
+    let mut f = Fixture::new("hnsw");
+    f.embedding.remote.dimensions = 1024;
+    let store = f.open();
+    let mut vector = vec![0.; 1024];
+    vector[0] = 1.;
+    for n in 0..32 {
+        let name = format!("vector-{n}");
+        let token = store
+            .insert_knowledge(&name, &Content::new("sample"))
+            .unwrap();
+        store
+            .install_embedding("knowledge", &name, token, &vector)
+            .unwrap();
+    }
+    assert_eq!(store.vector_search_knowledge(&vector, 5).unwrap().len(), 5);
+    let mut admin = f.admin();
+    let extension:String=admin.query_one("SELECT n.nspname FROM pg_catalog.pg_extension e JOIN pg_catalog.pg_namespace n ON n.oid=e.extnamespace WHERE e.extname='vector'",&[]).unwrap().get(0);
+    let op = format!("OPERATOR(\"{}\".<=>)", extension.replace('"', "\"\""));
+    let query = format!(
+        "EXPLAIN (FORMAT JSON) SELECT name FROM \"{}\".knowledge WHERE embedding IS NOT NULL ORDER BY embedding {op} $1 LIMIT 5",
+        f.config.schema
+    );
+    let v = pgvector::Vector::from(vector.clone());
+    // Small fixtures prefer sequential scans naturally. Disable them to verify
+    // the ANN access path is available; this is not a throughput benchmark.
+    admin.batch_execute("SET enable_seqscan=off").unwrap();
+    let plan: serde_json::Value = admin.query_one(&query, &[&v]).unwrap().get(0);
+    assert!(plan.to_string().contains("knowledge_embedding_hnsw_idx"));
+    eprintln!("1024D HNSW plan: {plan}");
+    let mut exact = Fixture::new("none");
+    exact.embedding.remote.dimensions = 1024;
+    let target = exact.open();
+    target.import_snapshot(&store.snapshot().unwrap()).unwrap();
+    let exact_query = query.replace(&f.config.schema, &exact.config.schema);
+    admin.batch_execute("SET enable_seqscan=on").unwrap();
+    let plan: serde_json::Value = admin.query_one(&exact_query, &[&v]).unwrap().get(0);
+    assert!(plan.to_string().contains("Seq Scan"));
+    assert!(!plan.to_string().contains("hnsw_idx"));
+    assert_eq!(target.vector_search_knowledge(&vector, 5).unwrap().len(), 5);
+    eprintln!("1024D exact plan: {plan}");
+}
+
+// Fault scenarios run in child test processes: no process-wide environment
+// mutation races with PostgreSQL clients or other Rust tests.
+fn run_fault_child(test: &str, scenario: &str, url: &str) {
+    let result = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--ignored", "--exact", test, "--nocapture"])
+        .env("HYPATIA_PG_FAULT_SCENARIO", scenario)
+        .env("HYPATIA_TEST_POSTGRES_URL", url)
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "fault child failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+fn test_connection(database: Option<&str>, role: Option<&str>, port: Option<u16>) -> String {
+    let original: postgres::Config = std::env::var("HYPATIA_TEST_POSTGRES_URL")
+        .unwrap()
+        .parse()
+        .unwrap();
+    let host = match &original.get_hosts()[0] {
+        postgres::config::Host::Tcp(h) => h.clone(),
+        #[cfg(unix)]
+        postgres::config::Host::Unix(p) => p.to_string_lossy().into_owned(),
+    };
+    let quote = |s: &str| format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"));
+    let user = role.or(original.get_user()).unwrap_or("postgres");
+    let password = if role.is_some() {
+        "hypatia-role-test-only"
+    } else {
+        std::str::from_utf8(original.get_password().unwrap_or_default()).unwrap()
+    };
+    format!(
+        "host={} port={} user={} password={} dbname={} sslmode=disable",
+        quote(&host),
+        port.unwrap_or_else(|| original.get_ports().first().copied().unwrap_or(5432)),
+        quote(user),
+        quote(password),
+        quote(database.or(original.get_dbname()).unwrap_or("postgres"))
+    )
+}
+#[test]
+#[ignore = "requires PostgreSQL admin privileges in a disposable test cluster"]
+fn missing_extension_and_permission_errors() {
+    let f = Fixture::new("none");
+    if let Ok(scenario) = std::env::var("HYPATIA_PG_FAULT_SCENARIO") {
+        let error = match PgStore::open(&f.config, &f.vector, &f.embedding) {
+            Ok(_) => panic!("fault scenario unexpectedly opened"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            error.contains(if scenario == "extension" {
+                "preinstalled"
+            } else {
+                "42501"
+            }),
+            "{error}"
+        );
+        return;
+    }
+    struct Resources {
+        admin: Client,
+        database: String,
+        role: String,
+    }
+    impl Drop for Resources {
+        fn drop(&mut self) {
+            let _ = self.admin.batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.database
+            ));
+            let _ = self
+                .admin
+                .batch_execute(&format!("DROP ROLE IF EXISTS \"{}\"", self.role));
+        }
+    }
+    let mut resources = Resources {
+        admin: f.admin(),
+        database: format!("{}_db", f.config.schema),
+        role: format!("{}_role", f.config.schema),
+    };
+    resources
+        .admin
+        .batch_execute(&format!(
+            "CREATE DATABASE \"{}\" TEMPLATE template0",
+            resources.database
+        ))
+        .unwrap();
+    run_fault_child(
+        "missing_extension_and_permission_errors",
+        "extension",
+        &test_connection(Some(&resources.database), None, None),
+    );
+    resources
+        .admin
+        .batch_execute(&format!(
+            "CREATE ROLE \"{}\" LOGIN PASSWORD 'hypatia-role-test-only'",
+            resources.role
+        ))
+        .unwrap();
+    run_fault_child(
+        "missing_extension_and_permission_errors",
+        "permission",
+        &test_connection(None, Some(&resources.role), None),
+    );
+}


### PR DESCRIPTION
Closes #15

## Summary

This PR adds an optional, per-shelf PostgreSQL + pgvector backend alongside the existing SQLite + FTS5 + usearch backend.

## What's included

- **New Cargo feature** `postgres-backend` keeps PG dependencies optional.
- **`shelf.toml` `[storage]` configuration** lets each shelf choose `sqlite` (default) or `pgvector`.
- **`ShelfBackend` abstraction** unifies SQLite and PostgreSQL behind the same storage trait.
- **PostgreSQL implementation** using JSONB, tsvector full-text search, and pgvector (HNSW or exact scan).
- **JSE PostgreSQL dialect compiler** that generates parameterized SQL instead of rewriting SQLite SQL.
- **Logical export/import** (snapshot + manifest + archives) for cross-backend migration and backups.
- **New CLI surface**: `hypatia import <source> [-s <shelf>] [--reembed]` and `hypatia backfill --reembed`.
- **Model identity tracking** so vectors from different models cannot be silently mixed.
- **Security details**: connection strings/passwords are not logged, exported, or included in errors.

## Documentation

- `docs/pgvector-backend-analysis.md` — design analysis and decision record
- `docs/pgvector-backend.md` — user-facing configuration and migration guide
- `README.md` and `docs/design.md` updated to describe the dual-backend architecture

## Verification

- `cargo check` passes
- `cargo check --features postgres-backend` passes
- `cargo clippy --all-targets` passes with no errors (pre-existing style warnings remain in benchmark tests)
- `cargo test`: 168 passed, 2 failed due to symlink permission limits in the current sandbox (not code bugs)
- `bash scripts/test-pgvector.sh` covers PG feature tests against a disposable pgvector container

## Known limitations

- PG backend does not automatically share `archives/` across machines; operators must share the directory or use export/import.
- Switching `backend = "pgvector"` does not migrate existing SQLite data; use `export` → `import`.
- HNSW index supports up to 2000 dimensions; higher dimensions require `storage.vector.index = "none"`.
- Cross-compilation with `native-tls` has not been verified for all targets.

---

/cc @MarchLiu